### PR TITLE
Add OpenAPI 3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,19 @@ The SwaggerTest's assertion process is based on throwing exceptions if some vali
 
 You can use the Swagger Test as:
 
-- Functional test sases
+- Functional test cases
 - Unit test cases
 - Runtime parameters validator
+
+# OpenAPI 3 Support
+
+Basic OpenAPI 3 Support has been added. This means that a Swagger specification that has been migrated to OpenAPI 3 should work here. The
+new OpenAPI 3 features, like callbacks and links, were not implemented. Previous specification versions are still supported.
 
 # Using it as Functional Test cases
 
 Swagger Test provide the class `SwaggerTestCase` for you extend and create a PHPUnit test case. The code will try to 
-make a request to your API Method and check if the request parameters, status and object returned are OK. 
+make a request to your API Method and check if the request parameters, status and object returned are OK.
 
 ```php
 <?php

--- a/src/SwaggerBody.php
+++ b/src/SwaggerBody.php
@@ -10,7 +10,7 @@ abstract class SwaggerBody
 {
     const SWAGGER_PROPERTIES="properties";
     const SWAGGER_REQUIRED="required";
-    
+
     /**
      * @var \ByJG\Swagger\SwaggerSchema
      */
@@ -264,6 +264,10 @@ abstract class SwaggerBody
         // Match Single Types
         if ($this->matchTypes($name, $schema, $body)) {
             return true;
+        }
+
+        if(!isset($schema['$ref']) && isset($schema['content'])) {
+            $schema['$ref'] = $schema['content'][key($schema['content'])]['schema']['$ref'];
         }
 
         // Get References and try to match it again

--- a/src/SwaggerRequestBody.php
+++ b/src/SwaggerRequestBody.php
@@ -24,6 +24,24 @@ class SwaggerRequestBody extends SwaggerBody
      */
     public function match($body)
     {
+        if ($this->swaggerSchema->getSpecificationVersion() === '3') {
+            if (isset($this->structure['content']) || isset($this->structure['$ref'])) {
+                if (isset($this->structure['required']) && $this->structure['required'] === true && empty($body)) {
+                    throw new RequiredArgumentNotFound('The body is required but it is empty');
+                }
+
+                if (isset($this->structure['$ref'])) {
+                    return $this->matchSchema($this->name, $this->structure, $body);
+                }
+
+                return $this->matchSchema($this->name, $this->structure['content'][key($this->structure['content'])]['schema'], $body);
+            }
+
+            if (!empty($body)) {
+                throw new InvalidDefinitionException('Body is passed but there is no request body definition');
+            }
+        }
+
         foreach ($this->structure as $parameter) {
             if ($parameter['in'] == "body") {
                 if (isset($parameter['required']) && $parameter['required'] === true && empty($body)) {
@@ -36,6 +54,8 @@ class SwaggerRequestBody extends SwaggerBody
         if (!empty($body)) {
             throw new InvalidDefinitionException('Body is passed but there is no request body definition');
         }
+
+
 
         return false;
     }

--- a/src/SwaggerRequester.php
+++ b/src/SwaggerRequester.php
@@ -152,10 +152,16 @@ class SwaggerRequester
         );
 
         // Defining Variables
-        $httpSchema = $this->swaggerSchema->getHttpSchema();
-        $host = $this->swaggerSchema->getHost();
-        $basePath = $this->swaggerSchema->getBasePath();
-        $pathName = $this->path;
+        $serverUrl = null;
+        if ($this->swaggerSchema->getSpecificationVersion() === '3') {
+            $serverUrl = $this->swaggerSchema->getServerUrl();
+        } else {
+            $httpSchema = $this->swaggerSchema->getHttpSchema();
+            $host = $this->swaggerSchema->getHost();
+            $basePath = $this->swaggerSchema->getBasePath();
+            $pathName = $this->path;
+            $serverUrl = "$httpSchema://$host$basePath$pathName$paramInQuery";
+        }
 
         // Check if the body is the expected before request
         $bodyRequestDef = $this->swaggerSchema->getRequestParameters("$basePath$pathName", $this->method);
@@ -164,7 +170,7 @@ class SwaggerRequester
         // Make the request
         $request = new Request(
             $this->method,
-            "$httpSchema://$host$basePath$pathName$paramInQuery",
+            $serverUrl,
             $header,
             json_encode($this->requestBody)
         );

--- a/src/SwaggerResponseBody.php
+++ b/src/SwaggerResponseBody.php
@@ -17,13 +17,22 @@ class SwaggerResponseBody extends SwaggerBody
      */
     public function match($body)
     {
+        if ($this->swaggerSchema->getSpecificationVersion() === '3') {
+            if (!isset($this->structure['content'])) {
+                if (!empty($body)) {
+                    throw new NotMatchedException("Expected empty body for " . $this->name);
+                }
+                return true;
+            }
+            return $this->matchSchema($this->name, $this->structure['content'][key($this->structure['content'])]['schema'], $body);
+        }
+
         if (!isset($this->structure['schema'])) {
             if (!empty($body)) {
                 throw new NotMatchedException("Expected empty body for " . $this->name);
             }
             return true;
         }
-
         return $this->matchSchema($this->name, $this->structure['schema'], $body);
     }
 }

--- a/tests/OpenApiBodyTestCase.php
+++ b/tests/OpenApiBodyTestCase.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Test;
+
+use ByJG\Swagger\SwaggerSchema;
+use PHPUnit\Framework\TestCase;
+
+class OpenApiBodyTestCase extends TestCase
+{
+    /**
+     * @param bool $allowNullValues
+     * @return SwaggerSchema
+     */
+    protected static function openApiSchema($allowNullValues = false)
+    {
+        return new SwaggerSchema(
+            self::getOpenApiJsonContent(),
+            $allowNullValues
+        );
+    }
+
+    /**
+     * @param bool $allowNullValues
+     * @return SwaggerSchema
+     */
+    protected static function openApiSchema2($allowNullValues = false)
+    {
+        return new SwaggerSchema(
+            self::getOpenApiJsonContent_No2(),
+            $allowNullValues
+        );
+    }
+
+    /**
+     * @return string
+     */
+    protected static function getOpenApiJsonContent()
+    {
+        return file_get_contents(__DIR__ . '/example/openapi.json');
+    }
+
+    /**
+     * @return string
+     */
+    protected static function getOpenApiJsonContent_No2()
+    {
+        return file_get_contents(__DIR__ . '/example/openapi2.json');
+    }
+}

--- a/tests/OpenApiRequestBodyTest.php
+++ b/tests/OpenApiRequestBodyTest.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace Test;
+
+class OpenApiRequestBodyTest extends OpenApiBodyTestCase
+{
+    /**
+     * @throws \ByJG\Swagger\Exception\DefinitionNotFoundException
+     * @throws \ByJG\Swagger\Exception\GenericSwaggerException
+     * @throws \ByJG\Swagger\Exception\HttpMethodNotFoundException
+     * @throws \ByJG\Swagger\Exception\InvalidDefinitionException
+     * @throws \ByJG\Swagger\Exception\InvalidRequestException
+     * @throws \ByJG\Swagger\Exception\NotMatchedException
+     * @throws \ByJG\Swagger\Exception\PathNotFoundException
+     * @throws \ByJG\Swagger\Exception\RequiredArgumentNotFound
+     */
+    public function testMatchRequestBody()
+    {
+        $body = [
+            "id" => "10",
+            "petId" => 50,
+            "quantity" => 1,
+            "shipDate" => '2010-10-20',
+            "status" => 'placed',
+            "complete" => true
+        ];
+
+        $requestParameter = self::openApiSchema()->getRequestParameters('/v2/store/order', 'post');
+        $this->assertTrue($requestParameter->match($body));
+    }
+
+    /**
+     * @expectedException \ByJG\Swagger\Exception\RequiredArgumentNotFound
+     * @expectedExceptionMessage The body is required
+     *
+     * @throws \ByJG\Swagger\Exception\DefinitionNotFoundException
+     * @throws \ByJG\Swagger\Exception\GenericSwaggerException
+     * @throws \ByJG\Swagger\Exception\HttpMethodNotFoundException
+     * @throws \ByJG\Swagger\Exception\InvalidDefinitionException
+     * @throws \ByJG\Swagger\Exception\InvalidRequestException
+     * @throws \ByJG\Swagger\Exception\NotMatchedException
+     * @throws \ByJG\Swagger\Exception\PathNotFoundException
+     * @throws \ByJG\Swagger\Exception\RequiredArgumentNotFound
+     */
+    public function testMatchRequiredRequestBodyEmpty()
+    {
+        $requestParameter = self::openApiSchema()->getRequestParameters('/v2/store/order', 'post');
+        $this->assertTrue($requestParameter->match(null));
+    }
+
+    /**
+     * @expectedException \ByJG\Swagger\Exception\InvalidDefinitionException
+     * @expectedExceptionMessage Body is passed but there is no request body definition
+     *
+     * @throws \ByJG\Swagger\Exception\DefinitionNotFoundException
+     * @throws \ByJG\Swagger\Exception\GenericSwaggerException
+     * @throws \ByJG\Swagger\Exception\HttpMethodNotFoundException
+     * @throws \ByJG\Swagger\Exception\InvalidDefinitionException
+     * @throws \ByJG\Swagger\Exception\InvalidRequestException
+     * @throws \ByJG\Swagger\Exception\NotMatchedException
+     * @throws \ByJG\Swagger\Exception\PathNotFoundException
+     * @throws \ByJG\Swagger\Exception\RequiredArgumentNotFound
+     */
+    public function testMatchInexistantBodyDefinition()
+    {
+        $body = [
+            "id" => "10",
+            "petId" => 50,
+            "quantity" => 1,
+            "shipDate" => '2010-10-20',
+            "status" => 'placed',
+            "complete" => true
+        ];
+
+        $requestParameter = self::openApiSchema()->getRequestParameters('/v2/pet/1', 'get');
+        $this->assertTrue($requestParameter->match($body));
+    }
+
+    /**
+     * @expectedException \ByJG\Swagger\Exception\NotMatchedException
+     * @expectedExceptionMessage Path expected an integer value
+     *
+     * @throws \ByJG\Swagger\Exception\HttpMethodNotFoundException
+     * @throws \ByJG\Swagger\Exception\NotMatchedException
+     * @throws \ByJG\Swagger\Exception\PathNotFoundException
+     */
+    public function testMatchDataType()
+    {
+        self::openApiSchema()->getRequestParameters('/v2/pet/STRING', 'get');
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @expectedException \ByJG\Swagger\Exception\NotMatchedException
+     * @expectedExceptionMessage Required property
+     *
+     * @throws \ByJG\Swagger\Exception\DefinitionNotFoundException
+     * @throws \ByJG\Swagger\Exception\GenericSwaggerException
+     * @throws \ByJG\Swagger\Exception\HttpMethodNotFoundException
+     * @throws \ByJG\Swagger\Exception\InvalidDefinitionException
+     * @throws \ByJG\Swagger\Exception\InvalidRequestException
+     * @throws \ByJG\Swagger\Exception\NotMatchedException
+     * @throws \ByJG\Swagger\Exception\PathNotFoundException
+     * @throws \ByJG\Swagger\Exception\RequiredArgumentNotFound
+     */
+    public function testMatchRequestBodyRequired1()
+    {
+        $body = [
+            "id" => "10",
+            "status" => "pending",
+        ];
+
+        $requestParameter = self::openApiSchema()->getRequestParameters('/v2/pet', 'post');
+        $this->assertTrue($requestParameter->match($body));
+    }
+
+    /**
+     * It is not OK when allowNullValues is false (as by default) { name: null }
+     * https://stackoverflow.com/questions/45575493/what-does-required-in-openapi-really-mean
+     *
+     * @expectedException \ByJG\Swagger\Exception\NotMatchedException
+     * @expectedExceptionMessage Value of property 'name' is null, but should be of type 'string'
+     *
+     * @throws \ByJG\Swagger\Exception\DefinitionNotFoundException
+     * @throws \ByJG\Swagger\Exception\GenericSwaggerException
+     * @throws \ByJG\Swagger\Exception\HttpMethodNotFoundException
+     * @throws \ByJG\Swagger\Exception\InvalidDefinitionException
+     * @throws \ByJG\Swagger\Exception\InvalidRequestException
+     * @throws \ByJG\Swagger\Exception\NotMatchedException
+     * @throws \ByJG\Swagger\Exception\PathNotFoundException
+     * @throws \ByJG\Swagger\Exception\RequiredArgumentNotFound
+     */
+    public function testMatchRequestBodyRequiredNullsNotAllowed()
+    {
+        $body = [
+            "id" => "10",
+            "status" => "pending",
+            "name" => null,
+            "photoUrls" => ["http://example.com/1", "http://example.com/2"]
+        ];
+
+        $requestParameter = self::openApiSchema()->getRequestParameters('/v2/pet', 'post');
+        $this->assertTrue($requestParameter->match($body));
+    }
+
+    /**
+     * @throws \ByJG\Swagger\Exception\DefinitionNotFoundException
+     * @throws \ByJG\Swagger\Exception\GenericSwaggerException
+     * @throws \ByJG\Swagger\Exception\HttpMethodNotFoundException
+     * @throws \ByJG\Swagger\Exception\InvalidDefinitionException
+     * @throws \ByJG\Swagger\Exception\InvalidRequestException
+     * @throws \ByJG\Swagger\Exception\NotMatchedException
+     * @throws \ByJG\Swagger\Exception\PathNotFoundException
+     * @throws \ByJG\Swagger\Exception\RequiredArgumentNotFound
+     */
+    public function testMatchRequestBodyRequiredNullsAllowed()
+    {
+        $allowNullValues = true;
+        $body = [
+            "id" => "10",
+            "status" => "pending",
+            "name" => null,
+            "photoUrls" => ["http://example.com/1", "http://example.com/2"]
+        ];
+
+        $requestParameter = self::openApiSchema($allowNullValues)->getRequestParameters('/v2/pet', 'post');
+        $this->assertTrue($requestParameter->match($body));
+    }
+
+    /**
+     * It is OK: { name: ""}
+     * https://stackoverflow.com/questions/45575493/what-does-required-in-openapi-really-mean
+     *
+     * @throws \ByJG\Swagger\Exception\DefinitionNotFoundException
+     * @throws \ByJG\Swagger\Exception\GenericSwaggerException
+     * @throws \ByJG\Swagger\Exception\HttpMethodNotFoundException
+     * @throws \ByJG\Swagger\Exception\InvalidDefinitionException
+     * @throws \ByJG\Swagger\Exception\InvalidRequestException
+     * @throws \ByJG\Swagger\Exception\NotMatchedException
+     * @throws \ByJG\Swagger\Exception\PathNotFoundException
+     * @throws \ByJG\Swagger\Exception\RequiredArgumentNotFound
+     */
+    public function testMatchRequestBodyRequired3()
+    {
+        $body = [
+            "id" => "10",
+            "status" => "pending",
+            "name" => "",
+            "photoUrls" => ["http://example.com/1", "http://example.com/2"]
+        ];
+
+        $requestParameter = self::openApiSchema()->getRequestParameters('/v2/pet', 'post');
+        $this->assertTrue($requestParameter->match($body));
+    }
+
+    /**
+     * issue #21
+     *
+     * @throws \ByJG\Swagger\Exception\DefinitionNotFoundException
+     * @throws \ByJG\Swagger\Exception\GenericSwaggerException
+     * @throws \ByJG\Swagger\Exception\HttpMethodNotFoundException
+     * @throws \ByJG\Swagger\Exception\InvalidDefinitionException
+     * @throws \ByJG\Swagger\Exception\InvalidRequestException
+     * @throws \ByJG\Swagger\Exception\NotMatchedException
+     * @throws \ByJG\Swagger\Exception\PathNotFoundException
+     * @throws \ByJG\Swagger\Exception\RequiredArgumentNotFound
+     */
+    public function testMatchRequestBodyRequired_Issue21()
+    {
+        // Full Request
+        $body = [
+            "wallet_uuid" => "502a1aa3-5239-4d4b-af09-4dc24ac5f034",
+            "user_uuid" => "e7f6c18b-8094-4c2c-9987-1be5b7c46678"
+        ];
+
+        $requestParameter = $this->openApiSchema2()->getRequestParameters('/accounts/create', 'post');
+        $this->assertTrue($requestParameter->match($body));
+    }
+
+    /**
+     * Issue #21
+     * @expectedException \ByJG\Swagger\Exception\NotMatchedException
+     * @expectedExceptionMessage Required property 'user_uuid'
+     *
+     * @throws \ByJG\Swagger\Exception\DefinitionNotFoundException
+     * @throws \ByJG\Swagger\Exception\GenericSwaggerException
+     * @throws \ByJG\Swagger\Exception\HttpMethodNotFoundException
+     * @throws \ByJG\Swagger\Exception\InvalidDefinitionException
+     * @throws \ByJG\Swagger\Exception\InvalidRequestException
+     * @throws \ByJG\Swagger\Exception\NotMatchedException
+     * @throws \ByJG\Swagger\Exception\PathNotFoundException
+     * @throws \ByJG\Swagger\Exception\RequiredArgumentNotFound
+     */
+    public function testMatchRequestBodyRequired_Issue21_Required()
+    {
+        // Missing Request
+        $body = [
+            "wallet_uuid" => "502a1aa3-5239-4d4b-af09-4dc24ac5f034",
+        ];
+
+        $requestParameter = $this->openApiSchema2()->getRequestParameters('/accounts/create', 'post');
+        $requestParameter->match($body);
+    }
+}

--- a/tests/OpenApiResponseBodyTest.php
+++ b/tests/OpenApiResponseBodyTest.php
@@ -2,7 +2,7 @@
 
 namespace Test;
 
-class SwaggerResponseBodyTest extends SwaggerBodyTestCase
+class OpenApiResponseBodyTest extends OpenApiBodyTestCase
 {
     /**
      * @throws \ByJG\Swagger\Exception\DefinitionNotFoundException
@@ -15,7 +15,7 @@ class SwaggerResponseBodyTest extends SwaggerBodyTestCase
      */
     public function testMatchResponseBody()
     {
-        $schema = self::swaggerSchema();
+        $openApiSchema = self::openApiSchema();
 
         $body = [
             "id" => 10,
@@ -25,7 +25,8 @@ class SwaggerResponseBodyTest extends SwaggerBodyTestCase
             "status" => 'placed',
             "complete" => true
         ];
-        $responseParameter = $schema->getResponseParameters('/v2/store/order', 'post', 200);
+
+        $responseParameter = $openApiSchema->getResponseParameters('/v2/store/order', 'post', 200);
         $this->assertTrue($responseParameter->match($body));
 
         // Default
@@ -36,7 +37,8 @@ class SwaggerResponseBodyTest extends SwaggerBodyTestCase
             "shipDate" => '2010-10-20',
             "status" => 'placed'
         ];
-        $responseParameter = $schema->getResponseParameters('/v2/store/order', 'post', 200);
+
+        $responseParameter = $openApiSchema->getResponseParameters('/v2/store/order', 'post', 200);
         $this->assertTrue($responseParameter->match($body));
 
         // Number as string
@@ -48,7 +50,8 @@ class SwaggerResponseBodyTest extends SwaggerBodyTestCase
             "status" => 'placed',
             "complete" => true
         ];
-        $responseParameter = $schema->getResponseParameters('/v2/store/order', 'post', 200);
+
+        $responseParameter = $openApiSchema->getResponseParameters('/v2/store/order', 'post', 200);
         $this->assertTrue($responseParameter->match($body));
     }
 
@@ -74,7 +77,8 @@ class SwaggerResponseBodyTest extends SwaggerBodyTestCase
             "status" => 'notfound',
             "complete" => true
         ];
-        $responseParameter = self::swaggerSchema()->getResponseParameters('/v2/store/order', 'post', 200);
+
+        $responseParameter = self::openApiSchema()->getResponseParameters('/v2/store/order', 'post', 200);
         $this->assertTrue($responseParameter->match($body));
     }
 
@@ -100,13 +104,14 @@ class SwaggerResponseBodyTest extends SwaggerBodyTestCase
             "status" => 'placed',
             "complete" => true
         ];
-        $responseParameter = self::swaggerSchema()->getResponseParameters('/v2/store/order', 'post', 200);
+
+        $responseParameter = self::openApiSchema()->getResponseParameters('/v2/store/order', 'post', 200);
         $this->assertTrue($responseParameter->match($body));
     }
 
     /**
      * @expectedException \ByJG\Swagger\Exception\NotMatchedException
-     * @expectedExceptionMessage The property(ies) 'more' has not defined in '#/definitions/Order'
+     * @expectedExceptionMessage The property(ies) 'more' has not defined in '#/components/schemas/Order'
      *
      * @throws \ByJG\Swagger\Exception\DefinitionNotFoundException
      * @throws \ByJG\Swagger\Exception\GenericSwaggerException
@@ -127,7 +132,8 @@ class SwaggerResponseBodyTest extends SwaggerBodyTestCase
             "complete" => true,
             "more" => "value"
         ];
-        $responseParameter = self::swaggerSchema()->getResponseParameters('/v2/store/order', 'post', 200);
+
+        $responseParameter = self::openApiSchema()->getResponseParameters('/v2/store/order', 'post', 200);
         $this->assertTrue($responseParameter->match($body));
     }
 
@@ -147,7 +153,8 @@ class SwaggerResponseBodyTest extends SwaggerBodyTestCase
             "status"   => 'placed',
             "complete" => true
         ];
-        $responseParameter = self::swaggerSchema()->getResponseParameters('/v2/store/order', 'post', 200);
+
+        $responseParameter = self::openApiSchema()->getResponseParameters('/v2/store/order', 'post', 200);
         $this->assertTrue($responseParameter->match($body));
     }
 
@@ -168,7 +175,8 @@ class SwaggerResponseBodyTest extends SwaggerBodyTestCase
             "status"   => 'placed',
             "complete" => null
         ];
-        $responseParameter = self::swaggerSchema($allowNullValues)->getResponseParameters(
+
+        $responseParameter = self::openApiSchema($allowNullValues)->getResponseParameters(
             '/v2/store/order',
             'post',
             200
@@ -195,7 +203,8 @@ class SwaggerResponseBodyTest extends SwaggerBodyTestCase
             "status"   => 'placed',
             "complete" => null
         ];
-        $responseParameter = self::swaggerSchema()->getResponseParameters('/v2/store/order', 'post', 200);
+
+        $responseParameter = self::openApiSchema()->getResponseParameters('/v2/store/order', 'post', 200);
         $responseParameter->match($body);
     }
 
@@ -211,7 +220,8 @@ class SwaggerResponseBodyTest extends SwaggerBodyTestCase
     public function testMatchResponseBodyEmpty()
     {
         $body = null;
-        $responseParameter = self::swaggerSchema()->getResponseParameters('/v2/pet/10', 'get', 400);
+
+        $responseParameter = self::openApiSchema()->getResponseParameters('/v2/pet/10', 'get', 400);
         $this->assertTrue($responseParameter->match($body));
     }
 
@@ -230,7 +240,8 @@ class SwaggerResponseBodyTest extends SwaggerBodyTestCase
     public function testMatchResponseBodyNotEmpty()
     {
         $body = ['suppose'=>'not here'];
-        $responseParameter = self::swaggerSchema()->getResponseParameters('/v2/pet/10', 'get', 400);
+
+        $responseParameter = self::openApiSchema()->getResponseParameters('/v2/pet/10', 'get', 400);
         $this->assertTrue($responseParameter->match($body));
     }
 
@@ -267,7 +278,8 @@ class SwaggerResponseBodyTest extends SwaggerBodyTestCase
             ],
             "status" => 'available'
         ];
-        $responseParameter = self::swaggerSchema()->getResponseParameters('/v2/pet/10', 'get', 200);
+
+        $responseParameter = self::openApiSchema()->getResponseParameters('/v2/pet/10', 'get', 200);
         $this->assertTrue($responseParameter->match($body));
     }
 
@@ -302,7 +314,8 @@ class SwaggerResponseBodyTest extends SwaggerBodyTestCase
             ],
             "status" => 'available'
         ];
-        $responseParameter = self::swaggerSchema($allowNullValues)->getResponseParameters('/v2/pet/10', 'get', 200);
+
+        $responseParameter = self::openApiSchema($allowNullValues)->getResponseParameters('/v2/pet/10', 'get', 200);
         $this->assertTrue($responseParameter->match($body));
     }
 
@@ -320,21 +333,22 @@ class SwaggerResponseBodyTest extends SwaggerBodyTestCase
     public function testIssue9()
     {
         $body =
-        [
             [
                 [
-                    "isoCode" => "fr",
-                    "label" => "French",
-                    "isDefault" => true
+                    [
+                        "isoCode" => "fr",
+                        "label" => "French",
+                        "isDefault" => true
+                    ],
+                    [
+                        "isoCode" => "br",
+                        "label" => "Brazilian",
+                        "isDefault" => false
+                    ]
                 ],
-                [
-                    "isoCode" => "br",
-                    "label" => "Brazilian",
-                    "isDefault" => false
-                ]
-            ],
-        ];
-        $responseParameter = $this->swaggerSchema2()->getResponseParameters('/v2/languages', 'get', 200);
+            ];
+
+        $responseParameter = $this->openApiSchema2()->getResponseParameters('/v2/languages', 'get', 200);
         $this->assertTrue($responseParameter->match($body));
     }
 
@@ -366,7 +380,8 @@ class SwaggerResponseBodyTest extends SwaggerBodyTestCase
                     "isDefault" => false
                 ]
             ];
-        $responseParameter = $this->swaggerSchema2()->getResponseParameters('/v2/languages', 'get', 200);
+
+        $responseParameter = $this->openApiSchema2()->getResponseParameters('/v2/languages', 'get', 200);
         $this->assertTrue($responseParameter->match($body));
     }
 
@@ -384,15 +399,15 @@ class SwaggerResponseBodyTest extends SwaggerBodyTestCase
     public function testMatchAnyValue()
     {
         $body = "string";
-        $responseParameter = $this->swaggerSchema2()->getResponseParameters('/v2/anyvalue', 'get', 200);
+        $responseParameter = $this->openApiSchema2()->getResponseParameters('/v2/anyvalue', 'get', 200);
         $this->assertTrue($responseParameter->match($body));
 
         $body = 1000;
-        $responseParameter = $this->swaggerSchema2()->getResponseParameters('/v2/anyvalue', 'get', 200);
+        $responseParameter = $this->openApiSchema2()->getResponseParameters('/v2/anyvalue', 'get', 200);
         $this->assertTrue($responseParameter->match($body));
 
         $body = [ "test" => "10"];
-        $responseParameter = $this->swaggerSchema2()->getResponseParameters('/v2/anyvalue', 'get', 200);
+        $responseParameter = $this->openApiSchema2()->getResponseParameters('/v2/anyvalue', 'get', 200);
         $this->assertTrue($responseParameter->match($body));
     }
 }

--- a/tests/OpenApiSchemaTest.php
+++ b/tests/OpenApiSchemaTest.php
@@ -1,0 +1,494 @@
+<?php
+
+namespace Test;
+
+use ByJG\Swagger\SwaggerSchema;
+use PHPUnit\Framework\TestCase;
+
+class OpenApiSchemaTest extends TestCase
+{
+    /**
+     * @var SwaggerSchema
+     */
+    protected $openapiObject;
+
+    public function setUp()
+    {
+        $this->openapiObject = new SwaggerSchema(file_get_contents(__DIR__ . '/example/openapi.json'));
+    }
+
+    public function tearDown()
+    {
+        $this->openapiObject = null;
+    }
+
+    public function testGetBasePath()
+    {
+        $this->assertEquals('/v2', $this->openapiObject->getBasePath());
+    }
+
+    /**
+     * @throws \ByJG\Swagger\Exception\HttpMethodNotFoundException
+     * @throws \ByJG\Swagger\Exception\NotMatchedException
+     * @throws \ByJG\Swagger\Exception\PathNotFoundException
+     */
+    public function testGetPathDirectMatch()
+    {
+        $this->assertEquals(
+            [
+                'tags' => [
+                    'pet',
+                ],
+                'summary' => 'Add a new pet to the store',
+                'description' => '',
+                'operationId' => 'addPet',
+                'requestBody' => [
+                    '$ref' => '#/components/requestBodies/Pet',
+                ],
+                'responses' => [
+                    '405' => [
+                        'description' => 'Invalid input',
+                    ],
+                ],
+                'security' => [
+                    [
+                        'petstore_auth' => [
+                            'write:pets',
+                            'read:pets',
+                        ],
+                    ],
+                ],
+            ],
+            $this->openapiObject->getPathDefinition('/v2/pet', 'post')
+        );
+        $this->assertEquals(
+            [
+                'tags' => [
+                    'pet',
+                ],
+                'summary' => 'Update an existing pet',
+                'description' => '',
+                'operationId' => 'updatePet',
+                'requestBody' => [
+                    '$ref' => '#/components/requestBodies/Pet',
+                ],
+                'responses' => [
+                    '400' => [
+                        'description' => 'Invalid ID supplied',
+                    ],
+                    '404' => [
+                        'description' => 'Pet not found',
+                    ],
+                    '405' => [
+                        'description' => 'Validation exception',
+                    ],
+                ],
+                'security' => [
+                    [
+                        'petstore_auth' => [
+                            'write:pets',
+                            'read:pets',
+                        ],
+                    ],
+                ],
+            ],
+            $this->openapiObject->getPathDefinition('/v2/pet', 'put')
+        );
+    }
+
+    /**
+     * @throws \ByJG\Swagger\Exception\HttpMethodNotFoundException
+     * @throws \ByJG\Swagger\Exception\NotMatchedException
+     * @throws \ByJG\Swagger\Exception\PathNotFoundException
+     */
+    public function testGetPathPatternMatch()
+    {
+        $this->assertEquals(
+            [
+                'tags' => [
+                    'pet',
+                ],
+                'summary' => 'Find pet by ID',
+                'description' => 'Returns a single pet',
+                'operationId' => 'getPetById',
+                'parameters' => [
+                    [
+                        'name' => 'petId',
+                        'in' => 'path',
+                        'description' => 'ID of pet to return',
+                        'required' => true,
+                        'schema' => [
+                            'type' => 'integer',
+                            'format' => 'int64',
+                        ],
+                    ],
+                ],
+                'responses' => [
+                    '200' => [
+                        'description' => 'successful operation',
+                        'content' => [
+                            'application/xml' => [
+                                'schema' => [
+                                    '$ref' => '#/components/schemas/Pet',
+                                ],
+                            ],
+                            'application/json' => [
+                                'schema' => [
+                                    '$ref' => '#/components/schemas/Pet',
+                                ],
+                            ],
+                        ],
+                    ],
+                    '400' => [
+                        'description' => 'Invalid ID supplied',
+                    ],
+                    '404' => [
+                        'description' => 'Pet not found',
+                    ],
+                ],
+                'security' => [
+                    [
+                        'api_key' => [],
+                    ],
+                ],
+            ],
+            $this->openapiObject->getPathDefinition('/v2/pet/10', 'get')
+        );
+        $this->assertEquals(
+            [
+                'tags' => [
+                    'pet',
+                ],
+                'summary' => 'Updates a pet in the store with form data',
+                'description' => '',
+                'operationId' => 'updatePetWithForm',
+                'parameters' => [
+                    [
+                        'name' => 'petId',
+                        'in' => 'path',
+                        'description' => 'ID of pet that needs to be updated',
+                        'required' => true,
+                        'schema' => [
+                            'type' => 'integer',
+                            'format' => 'int64',
+                        ],
+                    ],
+                ],
+                'requestBody' => [
+                    'content' => [
+                        'application/x-www-form-urlencoded' => [
+                            'schema' => [
+                                'type' => 'object',
+                                'properties' => [
+                                    'name' => [
+                                        'description' => 'Updated name of the pet',
+                                        'type' => 'string',
+                                    ],
+                                    'status' => [
+                                        'description' => 'Updated status of the pet',
+                                        'type' => 'string',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'responses' => [
+                    '405' => [
+                        'description' => 'Invalid input',
+                    ],
+                ],
+                'security' => [
+                    [
+                        'petstore_auth' => [
+                            'write:pets',
+                            'read:pets',
+                        ],
+                    ],
+                ],
+            ],
+            $this->openapiObject->getPathDefinition('/v2/pet/10', 'post')
+        );
+        $this->assertEquals(
+            [
+                'tags' => [
+                    'pet',
+                ],
+                'summary' => 'Deletes a pet',
+                'description' => '',
+                'operationId' => 'deletePet',
+                'parameters' => [
+                    [
+                        'name' => 'api_key',
+                        'in' => 'header',
+                        'required' => false,
+                        'schema' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                    [
+                        'name' => 'petId',
+                        'in' => 'path',
+                        'description' => 'Pet id to delete',
+                        'required' => true,
+                        'schema' => [
+                            'type' => 'integer',
+                            'format' => 'int64',
+                        ],
+                    ],
+                ],
+                'responses' => [
+                    '400' => [
+                        'description' => 'Invalid ID supplied',
+                    ],
+                    '404' => [
+                        'description' => 'Pet not found',
+                    ],
+                ],
+                'security' => [
+                    [
+                        'petstore_auth' => [
+                            'write:pets',
+                            'read:pets',
+                        ],
+                    ],
+                ],
+            ],
+            $this->openapiObject->getPathDefinition('/v2/pet/10', 'delete')
+        );
+    }
+
+    /**
+     * @throws \ByJG\Swagger\Exception\HttpMethodNotFoundException
+     * @throws \ByJG\Swagger\Exception\NotMatchedException
+     * @throws \ByJG\Swagger\Exception\PathNotFoundException
+     */
+    public function testGetPathPatternMatch2()
+    {
+        $this->assertEquals(
+            [
+                'tags' => [
+                    'pet',
+                ],
+                'summary' => 'uploads an image',
+                'description' => '',
+                'operationId' => 'uploadFile',
+                'parameters' => [
+                    [
+                        'name' => 'petId',
+                        'in' => 'path',
+                        'description' => 'ID of pet to update',
+                        'required' => true,
+                        'schema' => [
+                            'type' => 'integer',
+                            'format' => 'int64',
+                        ],
+                    ],
+                ],
+                'requestBody' => [
+                    'content' => [
+                        'multipart/form-data' => [
+                            'schema' => [
+                                'type' => 'object',
+                                'properties' => [
+                                    'additionalMetadata' => [
+                                        'description' => 'Additional data to pass to server',
+                                        'type' => 'string',
+                                    ],
+                                    'file' => [
+                                        'description' => 'file to upload',
+                                        'type' => 'string',
+                                        'format' => 'binary',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'responses' => [
+                    '200' => [
+                        'description' => 'successful operation',
+                        'content' => [
+                            'application/json' => [
+                                'schema' => [
+                                    '$ref' => '#/components/schemas/ApiResponse',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'security' => [
+                    [
+                        'petstore_auth' => [
+                            'write:pets',
+                            'read:pets',
+                        ],
+                    ],
+                ],
+            ]
+            ,
+            $this->openapiObject->getPathDefinition('/v2/pet/10/uploadImage', 'post')
+        );
+    }
+
+    /**
+     * @expectedException \ByJG\Swagger\Exception\PathNotFoundException
+     *
+     * @throws \ByJG\Swagger\Exception\HttpMethodNotFoundException
+     * @throws \ByJG\Swagger\Exception\NotMatchedException
+     * @throws \ByJG\Swagger\Exception\PathNotFoundException
+     */
+    public function testGetPathFail()
+    {
+        $this->openapiObject->getPathDefinition('/v2/pets', 'get');
+    }
+
+    /**
+     * @expectedException \ByJG\Swagger\Exception\HttpMethodNotFoundException
+     *
+     * @throws \ByJG\Swagger\Exception\HttpMethodNotFoundException
+     * @throws \ByJG\Swagger\Exception\NotMatchedException
+     * @throws \ByJG\Swagger\Exception\PathNotFoundException
+     */
+    public function testPathExistsButMethodDont()
+    {
+        $this->openapiObject->getPathDefinition('/v2/pet', 'GET');
+    }
+
+    /**
+     * @throws \ByJG\Swagger\Exception\HttpMethodNotFoundException
+     * @throws \ByJG\Swagger\Exception\NotMatchedException
+     * @throws \ByJG\Swagger\Exception\PathNotFoundException
+     */
+    public function testGetPathStructure()
+    {
+        $pathDefintion = $this->openapiObject->getPathDefinition('/v2/pet', 'PUT');
+        $this->assertEquals(
+            [
+                'tags' => [
+                    'pet',
+                ],
+                'summary' => 'Update an existing pet',
+                'description' => '',
+                'operationId' => 'updatePet',
+                'requestBody' => [
+                    '$ref' => '#/components/requestBodies/Pet',
+                ],
+                'responses' => [
+                    '400' => [
+                        'description' => 'Invalid ID supplied',
+                    ],
+                    '404' => [
+                        'description' => 'Pet not found',
+                    ],
+                    '405' => [
+                        'description' => 'Validation exception',
+                    ],
+                ],
+                'security' => [
+                    [
+                        'petstore_auth' => [
+                            'write:pets',
+                            'read:pets',
+                        ],
+                    ]
+                ],
+            ],
+            $pathDefintion
+        );
+    }
+
+    /**
+     * @expectedException \ByJG\Swagger\Exception\InvalidDefinitionException
+     *
+     * @throws \ByJG\Swagger\Exception\DefinitionNotFoundException
+     * @throws \ByJG\Swagger\Exception\InvalidDefinitionException
+     */
+    public function testGetDefinitionFailed()
+    {
+        $this->openapiObject->getDefintion('Order');
+    }
+
+    /**
+     * @expectedException \ByJG\Swagger\Exception\InvalidDefinitionException
+     *
+     * @throws \ByJG\Swagger\Exception\DefinitionNotFoundException
+     * @throws \ByJG\Swagger\Exception\InvalidDefinitionException
+     */
+    public function testGetDefinitionFailed2()
+    {
+        $this->openapiObject->getDefintion('1/2/Order');
+    }
+
+    /**
+     * @expectedException \ByJG\Swagger\Exception\DefinitionNotFoundException
+     *
+     * @throws \ByJG\Swagger\Exception\DefinitionNotFoundException
+     * @throws \ByJG\Swagger\Exception\InvalidDefinitionException
+     */
+    public function testGetDefinitionFailed3()
+    {
+        $this->openapiObject->getDefintion('#/components/schemas/OrderNOtFound');
+    }
+
+    /**
+     * @throws \ByJG\Swagger\Exception\DefinitionNotFoundException
+     * @throws \ByJG\Swagger\Exception\InvalidDefinitionException
+     */
+    public function testGetDefinition()
+    {
+        $expected = [
+            "type"       => "object",
+            "properties" => [
+                "id"       => [
+                    "type"   => "integer",
+                    "format" => "int64",
+                ],
+                "petId"    => [
+                    "type"   => "integer",
+                    "format" => "int64",
+                ],
+                "quantity" => [
+                    "type"   => "integer",
+                    "format" => "int32",
+                ],
+                "shipDate" => [
+                    "type"   => "string",
+                    "format" => "date-time",
+                ],
+                "status"   => [
+                    "type"        => "string",
+                    "description" => "Order Status",
+                    "enum"        => [
+                        "placed",
+                        "approved",
+                        "delivered",
+                    ],
+                ],
+                "complete" => [
+                    "type"    => "boolean",
+                    "default" => false,
+                ],
+            ],
+            "xml"        => [
+                "name" => "Order",
+            ],
+        ];
+
+        $order = $this->openapiObject->getDefintion('#/components/schemas/Order');
+        $this->assertEquals($expected, $order);
+    }
+
+    public function testItNotAllowsNullValuesByDefault()
+    {
+        $schema = new SwaggerSchema('{}');
+        $this->assertFalse($schema->isAllowNullValues());
+    }
+
+    public function testItAllowsNullValues()
+    {
+        $allowNullValues = true;
+        $schema = new SwaggerSchema('{}', $allowNullValues);
+        $this->assertTrue($schema->isAllowNullValues());
+    }
+}

--- a/tests/example/openapi.json
+++ b/tests/example/openapi.json
@@ -1,0 +1,1062 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "description": "This is a sample server Petstore server.  You can find out more about\nSwagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net,\n`special-key` to test the authorization filters.",
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "email": "apiteam@swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "tags": [
+    {
+      "name": "pet",
+      "description": "Everything about your Pets",
+      "externalDocs": {
+        "description": "Find out more",
+        "url": "http://swagger.io"
+      }
+    },
+    {
+      "name": "store",
+      "description": "Access to Petstore orders"
+    },
+    {
+      "name": "user",
+      "description": "Operations about user",
+      "externalDocs": {
+        "description": "Find out more about our store",
+        "url": "http://swagger.io"
+      }
+    }
+  ],
+  "paths": {
+    "/pet": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Add a new pet to the store",
+        "description": "",
+        "operationId": "addPet",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Pet"
+        },
+        "responses": {
+          "405": {
+            "description": "Invalid input"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Update an existing pet",
+        "description": "",
+        "operationId": "updatePet",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Pet"
+        },
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          },
+          "405": {
+            "description": "Validation exception"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/findByStatus": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Finds Pets by status",
+        "description": "Multiple status values can be provided with comma separated strings",
+        "operationId": "findPetsByStatus",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Status values that need to be considered for filter",
+            "required": true,
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "available",
+                  "pending",
+                  "sold"
+                ],
+                "default": "available"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid status value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/findByTags": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Finds Pets by tags",
+        "description": "Muliple tags can be provided with comma separated strings. Use tag1,\ntag2, tag3 for testing.",
+        "operationId": "findPetsByTags",
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "Tags to filter by",
+            "required": true,
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid tag value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "deprecated": true
+      }
+    },
+    "/pet/{petId}": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Find pet by ID",
+        "description": "Returns a single pet",
+        "operationId": "getPetById",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to return",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Updates a pet in the store with form data",
+        "description": "",
+        "operationId": "updatePetWithForm",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet that needs to be updated",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "Updated name of the pet",
+                    "type": "string"
+                  },
+                  "status": {
+                    "description": "Updated status of the pet",
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "405": {
+            "description": "Invalid input"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Deletes a pet",
+        "description": "",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "api_key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "Pet id to delete",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/{petId}/uploadImage": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "uploads an image",
+        "description": "",
+        "operationId": "uploadFile",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to update",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "additionalMetadata": {
+                    "description": "Additional data to pass to server",
+                    "type": "string"
+                  },
+                  "file": {
+                    "description": "file to upload",
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/store/inventory": {
+      "get": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Returns pet inventories by status",
+        "description": "Returns a map of status codes to quantities",
+        "operationId": "getInventory",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/store/order": {
+      "post": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Place an order for a pet",
+        "description": "",
+        "operationId": "placeOrder",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Order"
+              }
+            }
+          },
+          "description": "order placed for purchasing the pet",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid Order"
+          }
+        }
+      }
+    },
+    "/store/order/{orderId}": {
+      "get": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Find purchase order by ID",
+        "description": "For valid response try integer IDs with value >= 1 and <= 10. Other\nvalues will generated exceptions",
+        "operationId": "getOrderById",
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of pet that needs to be fetched",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 1,
+              "maximum": 10
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Delete purchase order by ID",
+        "description": "For valid response try integer IDs with positive integer value. Negative\nor non-integer values will generate API errors",
+        "operationId": "deleteOrder",
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of the order that needs to be deleted",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      }
+    },
+    "/user": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Create user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "createUser",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          },
+          "description": "Created user object",
+          "required": true
+        },
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/user/createWithArray": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Creates list of users with given input array",
+        "description": "",
+        "operationId": "createUsersWithArrayInput",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/UserArray"
+        },
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/user/createWithList": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Creates list of users with given input array",
+        "description": "",
+        "operationId": "createUsersWithListInput",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/UserArray"
+        },
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/user/login": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Logs user into the system",
+        "description": "",
+        "operationId": "loginUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "query",
+            "description": "The user name for login",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "password",
+            "in": "query",
+            "description": "The password for login in clear text",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "headers": {
+              "X-Rate-Limit": {
+                "description": "calls per hour allowed by the user",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              },
+              "X-Expires-After": {
+                "description": "date in UTC when token expires",
+                "schema": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            },
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid username/password supplied"
+          }
+        }
+      }
+    },
+    "/user/logout": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Logs out current logged in user session",
+        "description": "",
+        "operationId": "logoutUser",
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/user/{username}": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Get user by user name",
+        "description": "",
+        "operationId": "getUserByName",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be fetched. Use user1 for testing. ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Updated user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "updateUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "name that need to be updated",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          },
+          "description": "Updated user object",
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "description": "Invalid user supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Delete user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "deleteUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be deleted",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      }
+    }
+  },
+  "externalDocs": {
+    "description": "Find out more about Swagger",
+    "url": "http://swagger.io"
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/v2"
+    }
+  ],
+  "components": {
+    "requestBodies": {
+      "UserArray": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          }
+        },
+        "description": "List of user object",
+        "required": true
+      },
+      "Pet": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Pet"
+            }
+          },
+          "application/xml": {
+            "schema": {
+              "$ref": "#/components/schemas/Pet"
+            }
+          }
+        },
+        "description": "Pet object that needs to be added to the store",
+        "required": true
+      }
+    },
+    "securitySchemes": {
+      "petstore_auth": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      },
+      "api_key": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "header"
+      }
+    },
+    "schemas": {
+      "Order": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "petId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "quantity": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "shipDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "description": "Order Status",
+            "enum": [
+              "placed",
+              "approved",
+              "delivered"
+            ]
+          },
+          "complete": {
+            "type": "boolean",
+            "default": false
+          }
+        },
+        "xml": {
+          "name": "Order"
+        }
+      },
+      "Category": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "xml": {
+          "name": "Category"
+        }
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "username": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "phone": {
+            "type": "string"
+          },
+          "userStatus": {
+            "type": "integer",
+            "format": "int32",
+            "description": "User Status"
+          }
+        },
+        "xml": {
+          "name": "User"
+        }
+      },
+      "Tag": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "xml": {
+          "name": "Tag"
+        }
+      },
+      "Pet": {
+        "type": "object",
+        "required": [
+          "name",
+          "photoUrls"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "category": {
+            "$ref": "#/components/schemas/Category"
+          },
+          "name": {
+            "type": "string",
+            "example": "doggie"
+          },
+          "photoUrls": {
+            "type": "array",
+            "xml": {
+              "name": "photoUrl",
+              "wrapped": true
+            },
+            "items": {
+              "type": "string"
+            }
+          },
+          "tags": {
+            "type": "array",
+            "xml": {
+              "name": "tag",
+              "wrapped": true
+            },
+            "items": {
+              "$ref": "#/components/schemas/Tag"
+            }
+          },
+          "status": {
+            "type": "string",
+            "description": "pet status in the store",
+            "enum": [
+              "available",
+              "pending",
+              "sold"
+            ]
+          }
+        },
+        "xml": {
+          "name": "Pet"
+        }
+      },
+      "ApiResponse": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/example/openapi2.json
+++ b/tests/example/openapi2.json
@@ -1,0 +1,162 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "description": "This is a sample server Petstore server.  You can find out more about\nSwagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net,\n`special-key` to test the authorization filters.",
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "email": "apiteam@swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "paths": {
+    "/languages": {
+      "get": {
+        "tags": [
+          "general"
+        ],
+        "summary": "Get list of languages details for the specified site",
+        "parameters": [
+          {
+            "name": "site",
+            "in": "query",
+            "description": "Application context\n\nExample: 'sl'\n",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "JSON object",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "description": "languages result",
+                  "items": {
+                    "$ref": "#/components/schemas/LanguageData"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/anyvalue": {
+      "get": {
+        "tags": [
+          "general"
+        ],
+        "summary": "Get a response that could be any value",
+        "responses": {
+          "200": {
+            "description": "Returns any value",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnyValue"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/accounts/create": {
+      "post": {
+        "tags": [
+          "accounts"
+        ],
+        "summary": "create an account",
+        "description": "create an account",
+        "operationId": "createAccount",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "wallet_uuid",
+                  "user_uuid"
+                ],
+                "properties": {
+                  "wallet_uuid": {
+                    "description": "wallet id",
+                    "type": "string",
+                    "format": "uuid",
+                    "default": "502a1aa3-5239-4d4b-af09-4dc24ac5f034"
+                  },
+                  "user_uuid": {
+                    "description": "user id",
+                    "type": "string",
+                    "format": "uuid",
+                    "default": "e7f6c18b-8094-4c2c-9987-1be5b7c46678"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          },
+          "204": {
+            "description": "Account not found"
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          }
+        }
+      }
+    }
+  },
+  "externalDocs": {
+    "description": "Find out more about Swagger",
+    "url": "http://swagger.io"
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/v2"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "LanguageData": {
+        "type": "array",
+        "description": "Languages data",
+        "items": {
+          "$ref": "#/components/schemas/LanguageData_inner"
+        }
+      },
+      "LanguageData_inner": {
+        "properties": {
+          "isoCode": {
+            "$ref": "#/components/schemas/Language"
+          },
+          "label": {
+            "type": "string",
+            "description": "Language label in extracted language"
+          },
+          "isDefault": {
+            "type": "boolean",
+            "description": "Is the default language for the site"
+          }
+        }
+      },
+      "Language": {
+        "type": "string",
+        "description": "Language ISO 639-1 (2 characters)",
+        "example": "fr"
+      },
+      "AnyValue": {}
+    }
+  }
+}


### PR DESCRIPTION
Add basic OpenAPI 3 support. This means that a Swagger specification
that was migrated to OpenAPI 3 should work without issues. The new