### PR TITLE
Optional HTTP transport

### DIFF
--- a/src/AbstractRequester.php
+++ b/src/AbstractRequester.php
@@ -1,0 +1,249 @@
+<?php
+
+namespace ByJG\Swagger;
+
+use ByJG\Swagger\Exception\NotMatchedException;
+use ByJG\Swagger\Exception\StatusCodeNotMatchedException;
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Psr7\Request;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Abstract baseclass for request handlers.
+ *
+ * The baseclass provides processing and verification of request and response.
+ * It only delegates the actual message exchange to the derived class. For the
+ * messages, it uses the PSR-7 implementation from Guzzle.
+ *
+ * This is an implementation of the Template Method Patttern
+ * (https://en.wikipedia.org/wiki/Template_method_pattern).
+ */
+abstract class AbstractRequester
+{
+    protected $method = 'get';
+    protected $path = '/';
+    protected $requestHeader = [];
+    protected $query = [];
+    protected $requestBody = null;
+    /**
+     * @var SwaggerSchema
+     */
+    protected $swaggerSchema = null;
+
+    protected $statusExpected = 200;
+    protected $assertHeader = [];
+
+    public function __construct()
+    {
+    }
+
+    /**
+     * abstract function to be implemented by derived classes
+     *
+     * This function must be implemented by derived classes. It should process
+     * the given request and return an according response.
+     *
+     * @param RequestInterface $request
+     * @return ResponseInterface
+     */
+    abstract protected function handleRequest(RequestInterface $request);
+
+    /**
+     * @param SwaggerSchema $schema
+     * @return $this
+     */
+    public function withSwaggerSchema($schema)
+    {
+        $this->swaggerSchema = $schema;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasSwaggerSchema()
+    {
+        return !empty($this->swaggerSchema);
+    }
+
+    /**
+     * @param string $method
+     * @return $this
+     */
+    public function withMethod($method)
+    {
+        $this->method = $method;
+
+        return $this;
+    }
+
+    /**
+     * @param string $path
+     * @return $this
+     */
+    public function withPath($path)
+    {
+        $this->path = $path;
+
+        return $this;
+    }
+
+    /**
+     * @param array $requestHeader
+     * @return $this
+     */
+    public function withRequestHeader($requestHeader)
+    {
+        if (is_null($requestHeader)) {
+            $this->requestHeader = [];
+            return $this;
+        }
+
+        $this->requestHeader = array_merge($this->requestHeader, $requestHeader);
+
+        return $this;
+    }
+
+    /**
+     * @param array $query
+     * @return $this
+     */
+    public function withQuery($query)
+    {
+        if (is_null($query)) {
+            $this->query = [];
+            return $this;
+        }
+
+        $this->query = array_merge($this->query, $query);
+
+        return $this;
+    }
+
+    /**
+     * @param null $requestBody
+     * @return $this
+     */
+    public function withRequestBody($requestBody)
+    {
+        $this->requestBody = $requestBody;
+
+        return $this;
+    }
+
+    public function assertResponseCode($code)
+    {
+        $this->statusExpected = $code;
+
+        return $this;
+    }
+
+    public function assertHeaderContains($header, $contains)
+    {
+        $this->assertHeader[$header] = $contains;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     * @throws Exception\DefinitionNotFoundException
+     * @throws Exception\GenericSwaggerException
+     * @throws Exception\HttpMethodNotFoundException
+     * @throws Exception\InvalidDefinitionException
+     * @throws Exception\InvalidRequestException
+     * @throws Exception\PathNotFoundException
+     * @throws Exception\RequiredArgumentNotFound
+     * @throws NotMatchedException
+     * @throws StatusCodeNotMatchedException
+     * @throws GuzzleException
+     */
+    public function send()
+    {
+        // Preparing Parameters
+        $paramInQuery = null;
+        if (!empty($this->query)) {
+            $paramInQuery = '?' . http_build_query($this->query);
+        }
+
+        // Preparing Header
+        if (empty($this->requestHeader)) {
+            $this->requestHeader = [];
+        }
+        $header = array_merge(
+            [
+                'Accept' => 'application/json'
+            ],
+            $this->requestHeader
+        );
+
+        // Defining Variables
+        $serverUrl = null;
+        $basePath = "";
+        $pathName = "";
+        if ($this->swaggerSchema->getSpecificationVersion() === '3') {
+            $serverUrl = $this->swaggerSchema->getServerUrl();
+        } else {
+            $httpSchema = $this->swaggerSchema->getHttpSchema();
+            $host = $this->swaggerSchema->getHost();
+            $basePath = $this->swaggerSchema->getBasePath();
+            $pathName = $this->path;
+            $serverUrl = "$httpSchema://$host$basePath$pathName$paramInQuery";
+        }
+
+        // Check if the body is the expected before request
+        $bodyRequestDef = $this->swaggerSchema->getRequestParameters("$basePath$pathName", $this->method);
+        $bodyRequestDef->match($this->requestBody);
+
+        // Make the request
+        $request = new Request(
+            $this->method,
+            $serverUrl,
+            $header,
+            json_encode($this->requestBody)
+        );
+
+        $statusReturned = null;
+        try {
+            $response = $this->handleRequest($request);
+            $responseHeader = $response->getHeaders();
+            $responseBody = json_decode((string) $response->getBody(), true);
+            $statusReturned = $response->getStatusCode();
+        } catch (BadResponseException $ex) {
+            $responseHeader = $ex->getResponse()->getHeaders();
+            $responseBody = json_decode((string) $ex->getResponse()->getBody(), true);
+            $statusReturned = $ex->getResponse()->getStatusCode();
+        }
+
+        // Assert results
+        if ($this->statusExpected != $statusReturned) {
+            throw new StatusCodeNotMatchedException(
+                "Status code not matched $statusReturned",
+                $responseBody
+            );
+        }
+
+        $bodyResponseDef = $this->swaggerSchema->getResponseParameters(
+            "$basePath$pathName",
+            $this->method,
+            $this->statusExpected
+        );
+        $bodyResponseDef->match($responseBody);
+
+        if (count($this->assertHeader) > 0) {
+            foreach ($this->assertHeader as $key => $value) {
+                if (!isset($responseHeader[$key]) || strpos($responseHeader[$key][0], $value) === false) {
+                    throw new NotMatchedException(
+                        "Does not exists header '$key' with value '$value'",
+                        $responseHeader
+                    );
+                }
+            }
+        }
+
+        return $responseBody;
+    }
+}

--- a/src/SwaggerRequester.php
+++ b/src/SwaggerRequester.php
@@ -2,29 +2,16 @@
 
 namespace ByJG\Swagger;
 
-use ByJG\Swagger\Exception\NotMatchedException;
-use ByJG\Swagger\Exception\StatusCodeNotMatchedException;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\BadResponseException;
-use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\Psr7\Request;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
-class SwaggerRequester
+/**
+ * Request handler based on a Guzzle client.
+ */
+class SwaggerRequester extends AbstractRequester
 {
-    protected $method = 'get';
-    protected $path = '/';
-    protected $requestHeader = [];
-    protected $query = [];
-    protected $requestBody = null;
-    /**
-     * @var SwaggerSchema
-     */
-    protected $swaggerSchema = null;
-
-    protected $statusExpected = 200;
-    protected $assertHeader = [];
-
     /**
      * @var ClientInterface
      */
@@ -35,200 +22,8 @@ class SwaggerRequester
         $this->guzzleHttpClient = new Client(['headers' => ['User-Agent' => 'Swagger Test']]);
     }
 
-    /**
-     * @param SwaggerSchema $schema
-     * @return $this
-     */
-    public function withSwaggerSchema($schema)
+    protected function handleRequest(RequestInterface $request)
     {
-        $this->swaggerSchema = $schema;
-
-        return $this;
-    }
-
-    /**
-     * @return bool
-     */
-    public function hasSwaggerSchema()
-    {
-        return !empty($this->swaggerSchema);
-    }
-
-    /**
-     * @param string $method
-     * @return $this
-     */
-    public function withMethod($method)
-    {
-        $this->method = $method;
-
-        return $this;
-    }
-
-    /**
-     * @param string $path
-     * @return $this
-     */
-    public function withPath($path)
-    {
-        $this->path = $path;
-
-        return $this;
-    }
-
-    /**
-     * @param array $requestHeader
-     * @return $this
-     */
-    public function withRequestHeader($requestHeader)
-    {
-        if (is_null($requestHeader)) {
-            $this->requestHeader = [];
-            return $this;
-        }
-
-        $this->requestHeader = array_merge($this->requestHeader, $requestHeader);
-
-        return $this;
-    }
-
-    /**
-     * @param array $query
-     * @return $this
-     */
-    public function withQuery($query)
-    {
-        if (is_null($query)) {
-            $this->query = [];
-            return $this;
-        }
-
-        $this->query = array_merge($this->query, $query);
-
-        return $this;
-    }
-
-    /**
-     * @param null $requestBody
-     * @return $this
-     */
-    public function withRequestBody($requestBody)
-    {
-        $this->requestBody = $requestBody;
-
-        return $this;
-    }
-
-    public function assertResponseCode($code)
-    {
-        $this->statusExpected = $code;
-
-        return $this;
-    }
-
-    public function assertHeaderContains($header, $contains)
-    {
-        $this->assertHeader[$header] = $contains;
-
-        return $this;
-    }
-
-    /**
-     * @return mixed
-     * @throws Exception\DefinitionNotFoundException
-     * @throws Exception\GenericSwaggerException
-     * @throws Exception\HttpMethodNotFoundException
-     * @throws Exception\InvalidDefinitionException
-     * @throws Exception\InvalidRequestException
-     * @throws Exception\PathNotFoundException
-     * @throws Exception\RequiredArgumentNotFound
-     * @throws NotMatchedException
-     * @throws StatusCodeNotMatchedException
-     * @throws GuzzleException
-     */
-    public function send()
-    {
-        // Preparing Parameters
-        $paramInQuery = null;
-        if (!empty($this->query)) {
-            $paramInQuery = '?' . http_build_query($this->query);
-        }
-
-        // Preparing Header
-        if (empty($this->requestHeader)) {
-            $this->requestHeader = [];
-        }
-        $header = array_merge(
-            [
-                'Accept' => 'application/json'
-            ],
-            $this->requestHeader
-        );
-
-        // Defining Variables
-        $serverUrl = null;
-        $basePath = "";
-        $pathName = "";
-        if ($this->swaggerSchema->getSpecificationVersion() === '3') {
-            $serverUrl = $this->swaggerSchema->getServerUrl();
-        } else {
-            $httpSchema = $this->swaggerSchema->getHttpSchema();
-            $host = $this->swaggerSchema->getHost();
-            $basePath = $this->swaggerSchema->getBasePath();
-            $pathName = $this->path;
-            $serverUrl = "$httpSchema://$host$basePath$pathName$paramInQuery";
-        }
-
-        // Check if the body is the expected before request
-        $bodyRequestDef = $this->swaggerSchema->getRequestParameters("$basePath$pathName", $this->method);
-        $bodyRequestDef->match($this->requestBody);
-
-        // Make the request
-        $request = new Request(
-            $this->method,
-            $serverUrl,
-            $header,
-            json_encode($this->requestBody)
-        );
-
-        $statusReturned = null;
-        try {
-            $response = $this->guzzleHttpClient->send($request, ['allow_redirects' => false]);
-            $responseHeader = $response->getHeaders();
-            $responseBody = json_decode((string) $response->getBody(), true);
-            $statusReturned = $response->getStatusCode();
-        } catch (BadResponseException $ex) {
-            $responseHeader = $ex->getResponse()->getHeaders();
-            $responseBody = json_decode((string) $ex->getResponse()->getBody(), true);
-            $statusReturned = $ex->getResponse()->getStatusCode();
-        }
-
-        // Assert results
-        if ($this->statusExpected != $statusReturned) {
-            throw new StatusCodeNotMatchedException(
-                "Status code not matched $statusReturned",
-                $responseBody
-            );
-        }
-
-        $bodyResponseDef = $this->swaggerSchema->getResponseParameters(
-            "$basePath$pathName",
-            $this->method,
-            $this->statusExpected
-        );
-        $bodyResponseDef->match($responseBody);
-
-        if (count($this->assertHeader) > 0) {
-            foreach ($this->assertHeader as $key => $value) {
-                if (!isset($responseHeader[$key]) || strpos($responseHeader[$key][0], $value) === false) {
-                    throw new NotMatchedException(
-                        "Does not exists header '$key' with value '$value'",
-                        $responseHeader
-                    );
-                }
-            }
-        }
-
-        return $responseBody;
+        return $this->guzzleHttpClient->send($request, ['allow_redirects' => false]);
     }
 }

--- a/src/SwaggerRequester.php
+++ b/src/SwaggerRequester.php
@@ -56,7 +56,7 @@ class SwaggerRequester
 
     /**
      * @param string $method
-     * @return SwaggerRequester
+     * @return $this
      */
     public function withMethod($method)
     {
@@ -67,7 +67,7 @@ class SwaggerRequester
 
     /**
      * @param string $path
-     * @return SwaggerRequester
+     * @return $this
      */
     public function withPath($path)
     {
@@ -78,7 +78,7 @@ class SwaggerRequester
 
     /**
      * @param array $requestHeader
-     * @return SwaggerRequester
+     * @return $this
      */
     public function withRequestHeader($requestHeader)
     {
@@ -94,7 +94,7 @@ class SwaggerRequester
 
     /**
      * @param array $query
-     * @return SwaggerRequester
+     * @return $this
      */
     public function withQuery($query)
     {
@@ -110,7 +110,7 @@ class SwaggerRequester
 
     /**
      * @param null $requestBody
-     * @return SwaggerRequester
+     * @return $this
      */
     public function withRequestBody($requestBody)
     {

--- a/src/SwaggerTestCase.php
+++ b/src/SwaggerTestCase.php
@@ -4,6 +4,17 @@ namespace ByJG\Swagger;
 
 use ByJG\Swagger\Exception\GenericSwaggerException;
 use GuzzleHttp\Exception\GuzzleException;
+use ByJG\Swagger\AbstractRequester;
+use ByJG\Swagger\ApiRequester;
+use ByJG\Swagger\Base\Schema;
+use ByJG\Swagger\Exception\DefinitionNotFoundException;
+use ByJG\Swagger\Exception\HttpMethodNotFoundException;
+use ByJG\Swagger\Exception\InvalidDefinitionException;
+use ByJG\Swagger\Exception\NotMatchedException;
+use ByJG\Swagger\Exception\PathNotFoundException;
+use ByJG\Swagger\Exception\StatusCodeNotMatchedException;
+use ByJG\Swagger\Exception\GenericSwaggerException;
+use GuzzleHttp\GuzzleException;
 use PHPUnit\Framework\TestCase;
 
 abstract class SwaggerTestCase extends TestCase
@@ -76,7 +87,7 @@ abstract class SwaggerTestCase extends TestCase
     }
 
     /**
-     * @param SwaggerRequester $request
+     * @param AbstractRequester $request
      * @return mixed
      * @throws Exception\DefinitionNotFoundException
      * @throws Exception\HttpMethodNotFoundException
@@ -89,7 +100,7 @@ abstract class SwaggerTestCase extends TestCase
      * @throws GenericSwaggerException
      * @throws GuzzleException
      */
-    public function assertRequest(SwaggerRequester $request)
+    public function assertRequest(AbstractRequester $request)
     {
         // Add own swagger if nothing is passed.
         if (!$request->hasSwaggerSchema()) {


### PR DESCRIPTION
Support for not sending actual HTTP requests. We're trying to avoid sending actual requests, which brings the need to start a server process with an available network port and complicates debugging a bit. This PR splits between the request/response validation and the actual message exchange, so that the latter can also be done inside the same process. This is achieved by using a an abstract function that different derived classes can implement in different ways.

This PR is based on `master`, but I have it working for `version3` as well.