### PR TITLE
YAML support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ make a request to your API Method and check if the request parameters, status an
  */
 class MyTestCase extends \ByJG\ApiTools\ApiTestCase
 {
+    /**
+     * You can set this member to a JSON schema file, which is then automatically
+     * used for the tests. Alternatively, configure one using setSchema().
+     */
     protected $filePath = '/path/to/json/definition';
     
     /**

--- a/src/ApiTestCase.php
+++ b/src/ApiTestCase.php
@@ -9,16 +9,19 @@ use GuzzleHttp\GuzzleException;
 
 abstract class ApiTestCase extends BaseTestCase
 {
+    /** @var string|null */
+    protected $filePath;
 
     /**
      * @throws GenericSwaggerException
      */
     protected function setUp()
     {
-        if (empty($this->filePath)) {
-            throw new GenericSwaggerException('You have to define the property $filePath');
+        // load and configure the schema if a path is set
+        if (!empty($this->filePath)) {
+            $data = file_get_contents($this->filePath);
+            $schema = Schema::getInstance($data);
+            $this->setSchema($schema);
         }
-
-        $this->schema = Schema::getInstance(file_get_contents($this->filePath));
     }
 }

--- a/src/ApiTestCaseNew.php
+++ b/src/ApiTestCaseNew.php
@@ -14,16 +14,19 @@ use GuzzleHttp\GuzzleException;
  */
 abstract class ApiTestCaseNew extends BaseTestCase
 {
+    /** @var string|null */
+    protected $filePath;
 
     /**
      * @throws GenericSwaggerException
      */
     protected function setUp(): void
     {
-        if (empty($this->filePath)) {
-            throw new GenericSwaggerException('You have to define the property $filePath');
+        // load and configure the schema if a path is set
+        if (!empty($this->filePath)) {
+            $data = file_get_contents($this->filePath);
+            $schema = Schema::getInstance($data);
+            $this->setSchema($schema);
         }
-
-        $this->schema = Schema::getInstance(file_get_contents($this->filePath));
     }
 }

--- a/src/Base/BaseTestCase.php
+++ b/src/Base/BaseTestCase.php
@@ -22,7 +22,17 @@ abstract class BaseTestCase extends TestCase
      */
     protected $schema;
 
-    protected $filePath;
+    /**
+     * configure the schema to use for requests
+     *
+     * When set, all requests without an own schema use this one instead.
+     *
+     * @param Schema|null $schema
+     */
+    public function setSchema($schema)
+    {
+        $this->schema = $schema;
+    }
 
     /**
      * @param string $method The HTTP Method: GET, PUT, DELETE, POST, etc
@@ -49,6 +59,9 @@ abstract class BaseTestCase extends TestCase
         $requestBody = null,
         $requestHeader = []
     ) {
+        if (!$this->schema) {
+            throw new GenericSwaggerException('You have to configure a schema for the testcase');
+        }
         $requester = new ApiRequester();
         $body = $requester
             ->withSchema($this->schema)
@@ -84,6 +97,9 @@ abstract class BaseTestCase extends TestCase
     {
         // Add own schema if nothing is passed.
         if (!$request->hasSchema()) {
+            if (!$this->schema) {
+                throw new GenericSwaggerException('You have to configure a schema for either the request or the testcase');
+            }
             $request->withSchema($this->schema);
         }
 

--- a/src/OpenApi/OpenApiSchema.php
+++ b/src/OpenApi/OpenApiSchema.php
@@ -9,19 +9,29 @@ use ByJG\ApiTools\Exception\InvalidDefinitionException;
 use ByJG\ApiTools\Exception\NotMatchedException;
 use ByJG\ApiTools\Exception\PathNotFoundException;
 use ByJG\Util\Uri;
+use InvalidArgumentException;
 
 class OpenApiSchema extends Schema
 {
 
     protected $serverVariables = [];
 
-
-    public function __construct($jsonFile)
+    /**
+     * Initialize with schema data, which can be a PHP array or encoded as JSON.
+     *
+     * @param array|string $data
+     */
+    public function __construct($data)
     {
-        if (!is_array($jsonFile)) {
-            $jsonFile = json_decode($jsonFile, true);
+        // when given a string, decode from JSON
+        if (is_string($data)) {
+            $data = json_decode($data, true);
         }
-        $this->jsonFile = $jsonFile;
+        // make sure we got an array
+        if (!is_array($data)) {
+            throw new InvalidArgumentException('schema must be given as array or JSON string');
+        }
+        $this->jsonFile = $data;
     }
 
     public function getServerUrl()

--- a/src/Swagger/SwaggerSchema.php
+++ b/src/Swagger/SwaggerSchema.php
@@ -8,15 +8,27 @@ use ByJG\ApiTools\Exception\HttpMethodNotFoundException;
 use ByJG\ApiTools\Exception\InvalidDefinitionException;
 use ByJG\ApiTools\Exception\NotMatchedException;
 use ByJG\ApiTools\Exception\PathNotFoundException;
+use InvalidArgumentException;
 
 class SwaggerSchema extends Schema
 {
-    public function __construct($jsonFile, $allowNullValues = false)
+    /**
+     * Initialize with schema data, which can be a PHP array or encoded as JSON.
+     *
+     * @param array|string $data
+     * @param bool $allowNullValues
+     */
+    public function __construct($data, $allowNullValues = false)
     {
-        if (!is_array($jsonFile)) {
-            $jsonFile = json_decode($jsonFile, true);
+        // when given a string, decode from JSON
+        if (is_string($data)) {
+            $data = json_decode($data, true);
         }
-        $this->jsonFile = $jsonFile;
+        // make sure we got an array
+        if (!is_array($data)) {
+            throw new InvalidArgumentException('schema must be given as array or JSON string');
+        }
+        $this->jsonFile = $data;
         $this->allowNullValues = (bool) $allowNullValues;
     }
 


### PR DESCRIPTION
This adds support for schema files in different formats. It does so by taking either a `Schema` instance or the decoded data (PHP `array`). For me, the most important part is that this allows the use of YAML as alternative file format, by simply decoding it and using the resulting PHP `array`.
