### PR TITLE
Fix bug in request processing

### DIFF
--- a/src/AbstractRequester.php
+++ b/src/AbstractRequester.php
@@ -179,7 +179,7 @@ abstract class AbstractRequester
         );
 
         // Defining Variables
-        $serverUrl = $this->schema->getServerUrl() . $paramInQuery;
+        $serverUrl = $this->schema->getServerUrl();
         $basePath = $this->schema->getBasePath();
         $pathName = $this->path;
 


### PR DESCRIPTION
I think that this simple change is correct. You can observe a bogus path in the request object without this fix. I must admit that this change doesn't have any effect on the unit tests though. Also, I couldn't find any tests actually using the `withQuery()` method. BTW: Without having investigated the issue, I wonder if this handles multiple values for a query parameter (`https://example.com/?color=blue&color=green`).

#### Background
Here's the code which I wrote and which seemed to work due to a combination of bugs and counter-bugs:
```php
        $request = $this->createRequester()
            ->withMethod('GET')
            ->withPath('/v1/attributes?name=color,ids=550')
            ->assertResponseCode(404);
```
The code should have been this instead:
```php
        $request = $this->createRequester()
            ->withMethod('GET')
            ->withPath('/v1/attributes')
            ->withQuery([
                'name' => 'color',
                'ids' => '550',
            ])
            ->assertResponseCode(404);
```

