### PR TITLE
Fix match ResponseBody with $ref and no content

### DIFF
--- a/src/OpenApi/OpenApiResponseBody.php
+++ b/src/OpenApi/OpenApiResponseBody.php
@@ -33,8 +33,7 @@ class OpenApiResponseBody extends Body
             $defintion = $this->schema->getDefinition($this->structure['$ref']);
             return $this->matchSchema($this->name, $defintion, $body);
         }
-        else {
-            return $this->matchSchema($this->name, $this->structure['content'][key($this->structure['content'])]['schema'], $body);
-        }
+        
+        return $this->matchSchema($this->name, $this->structure['content'][key($this->structure['content'])]['schema'], $body);
     }
 }

--- a/src/OpenApi/OpenApiResponseBody.php
+++ b/src/OpenApi/OpenApiResponseBody.php
@@ -22,12 +22,19 @@ class OpenApiResponseBody extends Body
      */
     public function match($body)
     {
-        if (!isset($this->structure['content'])) {
+        if (!isset($this->structure['content']) && !isset($this->structure['$ref'])) {
             if (!empty($body)) {
                 throw new NotMatchedException("Expected empty body for " . $this->name);
             }
             return true;
         }
-        return $this->matchSchema($this->name, $this->structure['content'][key($this->structure['content'])]['schema'], $body);
+        
+        if(!isset($this->structure['content']) && isset($this->structure['$ref'])){
+            $defintion = $this->schema->getDefinition($this->structure['$ref']);
+            return $this->matchSchema($this->name, $defintion, $body);
+        }
+        else {
+            return $this->matchSchema($this->name, $this->structure['content'][key($this->structure['content'])]['schema'], $body);
+        }
     }
 }

--- a/tests/OpenApiBodyTestCase.php
+++ b/tests/OpenApiBodyTestCase.php
@@ -44,6 +44,18 @@ class OpenApiBodyTestCase extends TestCase
     }
 
     /**
+     * @param bool $allowNullValues
+     * @return OpenApiSchema
+     */
+    protected static function openApiSchema5($allowNullValues = false)
+    {
+        return \ByJG\ApiTools\Base\Schema::getInstance(
+            self::getOpenApiJsonContent_No5(),
+            $allowNullValues
+        );
+    }
+
+    /**
      * @return string
      */
     protected static function getOpenApiJsonContent()
@@ -65,5 +77,13 @@ class OpenApiBodyTestCase extends TestCase
     protected static function getOpenApiJsonContent_No3()
     {
         return file_get_contents(__DIR__ . '/example/openapi3.json');
+    }
+
+    /**
+     * @return string
+     */
+    protected static function getOpenApiJsonContent_No5()
+    {
+        return file_get_contents(__DIR__ . '/example/openapi5.json');
     }
 }

--- a/tests/OpenApiResponseBodyTest.php
+++ b/tests/OpenApiResponseBodyTest.php
@@ -56,6 +56,28 @@ class OpenApiResponseBodyTest extends OpenApiBodyTestCase
     }
 
     /**
+     * @throws \ByJG\ApiTools\Exception\DefinitionNotFoundException
+     * @throws \ByJG\ApiTools\Exception\GenericSwaggerException
+     * @throws \ByJG\ApiTools\Exception\HttpMethodNotFoundException
+     * @throws \ByJG\ApiTools\Exception\InvalidDefinitionException
+     * @throws \ByJG\ApiTools\Exception\InvalidRequestException
+     * @throws \ByJG\ApiTools\Exception\NotMatchedException
+     * @throws \ByJG\ApiTools\Exception\PathNotFoundException
+     */
+    public function testMatchResponseBodyWithRefInsteadOfContent()
+    {
+        $openApiSchema = self::openApiSchema5();
+
+        $body = [
+            "param_response_1" => "example1",
+            "param_response_2" => "example2"            
+        ];
+
+        $responseParameter = $openApiSchema->getResponseParameters('/v1/test', 'post', 201);
+        $this->assertTrue($responseParameter->match($body));
+    }
+
+    /**
      * @expectedException \ByJG\ApiTools\Exception\NotMatchedException
      * @expectedExceptionMessage Value 'notfound' in 'status' not matched in ENUM
      *

--- a/tests/example/openapi5.json
+++ b/tests/example/openapi5.json
@@ -1,0 +1,101 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "description": "API test",
+    "version": "0.0.1",
+    "title": "API-test"
+  },
+  "servers": [
+    {
+      "url": "https://127.0.0.1",
+      "description": "Instance of the API-test"
+    }
+  ],
+  "paths": {
+    "/v1/test": {
+      "post": {
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Test endpoint",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/TestBodyRequest"
+        },
+        "responses": {
+          "201": {
+            "$ref": "#/components/responses/TestBodyResponse"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "requestBodies": {
+      "TestBodyRequest": {
+        "description": "Test body",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/TestSchema"
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "TestBodyResponse": {
+        "description": "Test body response",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Success"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "TestSchema": {
+        "type": "object",
+        "required": [
+          "param1",
+          "param2",
+          "param3"
+        ],
+        "properties": {
+          "param1": {
+            "type": "string",
+            "description": "Param 1 description"
+          },
+          "param2": {
+            "type": "string",
+            "description": "Param 2 description"
+          },
+          "param3": {
+            "type": "string",
+            "description": "Param 3 description"
+          }
+        }
+      },
+      "Success": {
+        "type": "object",
+        "required": [
+          "param_response_1",
+          "param_response_2"
+        ],
+        "properties": {
+          "param_response_1": {
+            "type": "string",
+            "description": "param_response_1 description"
+          },
+          "param_response_2": {
+            "type": "string",
+            "description": "param_response_2 description"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hi,

I just found and error matching response bodies like this:

```
   response:
      '401':
         $ref: '#/components/responses/Unauthorized' 
```

This is because the 'content' tag is not present and you suppose there is no body in the response.