### PR TITLE
Fix allOf matching with refs

### DIFF
--- a/src/Base/Body.php
+++ b/src/Base/Body.php
@@ -378,6 +378,7 @@ abstract class Body
                     $schema = $this->schema->getDefinition($schema['$ref']);
                 }
             }
+            unset($schema);
             $mergedSchema = array_merge_recursive(...$allOfSchemas);
             return $this->matchSchema($name, $mergedSchema, $body);
         }

--- a/tests/OpenApiResponseBodyTest.php
+++ b/tests/OpenApiResponseBodyTest.php
@@ -449,6 +449,16 @@ class OpenApiResponseBodyTest extends OpenApiBodyTestCase
         $this->assertTrue($responseParameter->match($body));
     }
 
+    public function testMatchAllOf()
+    {
+        $body = ["name" => "Bob", "email" => "bob@example.com"];
+        $responseParameter = $this->openApiSchema2()->getResponseParameters('/v2/allof', 'get', 200);
+        $this->assertTrue($responseParameter->match($body));
+
+        $responseParameter = $this->openApiSchema2()->getResponseParameters('/v2/allofref', 'get', 200);
+        $this->assertTrue($responseParameter->match($body));
+    }
+
     public function testResponseDefault()
     {
         $body = [];

--- a/tests/example/openapi2.json
+++ b/tests/example/openapi2.json
@@ -116,6 +116,70 @@
           }
         }
       }
+    },
+    "/allof": {
+      "get": {
+        "tags": [
+          "general"
+        ],
+        "summary": "Get a response that should match two schemas",
+        "responses": {
+          "200": {
+            "description": "Returns any value",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "allOf": [
+                    {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "email": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/allofref": {
+      "get": {
+        "tags": [
+          "general"
+        ],
+        "summary": "Get a response that should match two schemas",
+        "responses": {
+          "200": {
+            "description": "Returns any value",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/NameObject"
+                    },
+                    {
+                      "$ref": "#/components/schemas/EmailObject"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "externalDocs": {
@@ -156,7 +220,21 @@
         "description": "Language ISO 639-1 (2 characters)",
         "example": "fr"
       },
-      "AnyValue": {}
+      "AnyValue": {},
+      "NameObject": {
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "EmailObject": {
+        "properties": {
+          "email": {
+            "type": "string"
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
`allOf` tried just to merge schemas recursively. But it failed when `allOf` items were refs. I propose to "unpack" refs before merging.