### PR TITLE
Fix: `allOf` match logic

### DIFF
--- a/src/Base/Body.php
+++ b/src/Base/Body.php
@@ -276,12 +276,14 @@ abstract class Body
      */
     public function matchObjectProperties($name, $schemaArray, $body)
     {
-        if (isset($schemaArray[self::SWAGGER_ADDITIONAL_PROPERTIES])) {
-            $additionalProperties = $schemaArray[self::SWAGGER_ADDITIONAL_PROPERTIES];
-            if ($additionalProperties === true) {
-                $schemaArray[self::SWAGGER_ADDITIONAL_PROPERTIES] = []; // Equivalent of 'any type'
-            }
-            if ($additionalProperties === false) {
+        if (!isset($schemaArray[self::SWAGGER_ADDITIONAL_PROPERTIES])) {
+            $schemaArray[self::SWAGGER_ADDITIONAL_PROPERTIES] = true;
+        }
+
+        if (is_bool($schemaArray[self::SWAGGER_ADDITIONAL_PROPERTIES])) {
+            if ($schemaArray[self::SWAGGER_ADDITIONAL_PROPERTIES]) {
+                $schemaArray[self::SWAGGER_ADDITIONAL_PROPERTIES] = [];
+            } else {
                 unset($schemaArray[self::SWAGGER_ADDITIONAL_PROPERTIES]);
             }
         }
@@ -361,6 +363,10 @@ abstract class Body
      */
     protected function matchSchema($name, $schemaArray, $body)
     {
+        if ($schemaArray === []) {
+            return true;
+        }
+
         // Match Single Types
         if ($this->matchTypes($name, $schemaArray, $body)) {
             return true;

--- a/src/Base/Body.php
+++ b/src/Base/Body.php
@@ -361,9 +361,9 @@ abstract class Body
         }
 
         // Get References and try to match it again
-        if (isset($schemaArray['$ref']) && !is_array($schemaArray['$ref'])) {
-            $defintion = $this->schema->getDefinition($schemaArray['$ref']);
-            return $this->matchSchema($schemaArray['$ref'], $defintion, $body);
+        if (isset($schemagArray['$ref']) && !is_array($schemaArray['$ref'])) {
+            $definition = $this->schema->getDefinition($schemaArray['$ref']);
+            return $this->matchSchema($schemaArray['$ref'], $definition, $body);
         }
 
         // Match object properties

--- a/src/Base/Body.php
+++ b/src/Base/Body.php
@@ -382,11 +382,6 @@ abstract class Body
             return $this->matchSchema($schemaArray['$ref'], $definition, $body);
         }
 
-        // Match object properties
-        if ($this->matchObjectProperties($name, $schemaArray, $body)) {
-            return true;
-        }
-
         if (isset($schemaArray['allOf'])) {
             $allOfSchemas = $schemaArray['allOf'];
             foreach ($allOfSchemas as $schema) {
@@ -413,6 +408,11 @@ abstract class Body
             }
 
             return $matched;
+        }
+
+        // Match object properties
+        if ($this->matchObjectProperties($name, $schemaArray, $body)) {
+            return true;
         }
 
         /**

--- a/tests/OpenApiResponseBodyTest.php
+++ b/tests/OpenApiResponseBodyTest.php
@@ -457,6 +457,10 @@ class OpenApiResponseBodyTest extends OpenApiBodyTestCase
 
         $responseParameter = $this->openApiSchema2()->getResponseParameters('/v2/allofref', 'get', 200);
         $this->assertTrue($responseParameter->match($body));
+
+        // password is not required
+        $responseParameter = $this->openApiSchema2()->getResponseParameters('/v2/nestedallofref', 'get', 200);
+        $this->assertTrue($responseParameter->match($body));
     }
 
     public function testResponseDefault()

--- a/tests/OpenApiSchemaTest.php
+++ b/tests/OpenApiSchemaTest.php
@@ -439,6 +439,7 @@ class OpenApiSchemaTest extends TestCase
     {
         $expected = [
             "type"       => "object",
+            "additionalProperties" => false,
             "properties" => [
                 "id"       => [
                     "type"   => "integer",

--- a/tests/SwaggerSchemaTest.php
+++ b/tests/SwaggerSchemaTest.php
@@ -479,6 +479,7 @@ class SwaggerSchemaTest extends TestCase
         $this->assertEquals(
             [
                 "type"       => "object",
+                "additionalProperties" => false,
                 "properties" => [
                     "id"       => [
                         "type"   => "integer",

--- a/tests/example/openapi.json
+++ b/tests/example/openapi.json
@@ -973,6 +973,7 @@
     "schemas": {
       "Order": {
         "type": "object",
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer",

--- a/tests/example/openapi2.json
+++ b/tests/example/openapi2.json
@@ -125,12 +125,11 @@
         "summary": "Get a response that should match two schemas",
         "responses": {
           "200": {
-            "description": "Returns any value",
+            "description": "Returns name and email",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true,
                   "allOf": [
                     {
                       "properties": {
@@ -162,7 +161,7 @@
         "summary": "Get a response that should match two schemas",
         "responses": {
           "200": {
-            "description": "Returns any value",
+            "description": "Returns name and email",
             "content": {
               "application/json": {
                 "schema": {
@@ -190,7 +189,7 @@
         "summary": "Get a response that should match two schemas",
         "responses": {
           "200": {
-            "description": "Returns any value",
+            "description": "Returns name, email and password",
             "content": {
               "application/json": {
                 "schema": {
@@ -201,7 +200,6 @@
                     },
                     {
                       "type": "object",
-                      "additionalProperties": true,
                       "properties": {
                         "password": {
                           "type": "string"
@@ -257,7 +255,6 @@
       },
       "AnyValue": {},
       "NameObject": {
-        "additionalProperties": true,
         "required": ["name"],
         "properties": {
           "name": {
@@ -266,7 +263,6 @@
         }
       },
       "EmailObject": {
-        "additionalProperties": true,
         "required": ["email"],
         "properties": {
           "email": {
@@ -275,7 +271,6 @@
         }
       },
       "NameEmailObject": {
-        "additionalProperties": true,
         "type": "object",
         "allOf": [
           {

--- a/tests/example/openapi2.json
+++ b/tests/example/openapi2.json
@@ -180,6 +180,39 @@
           }
         }
       }
+    },
+    "/nestedallofref": {
+      "get": {
+        "tags": [
+          "general"
+        ],
+        "summary": "Get a response that should match two schemas",
+        "responses": {
+          "200": {
+            "description": "Returns any value",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/NameEmailObject"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "password": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "externalDocs": {
@@ -222,6 +255,7 @@
       },
       "AnyValue": {},
       "NameObject": {
+        "required": ["name"],
         "properties": {
           "name": {
             "type": "string"
@@ -229,11 +263,23 @@
         }
       },
       "EmailObject": {
+        "required": ["email"],
         "properties": {
           "email": {
             "type": "string"
           }
         }
+      },
+      "NameEmailObject": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NameObject"
+          },
+          {
+            "$ref": "#/components/schemas/EmailObject"
+          }
+        ]
       }
     }
   }

--- a/tests/example/openapi2.json
+++ b/tests/example/openapi2.json
@@ -130,6 +130,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "additionalProperties": true,
                   "allOf": [
                     {
                       "properties": {
@@ -200,6 +201,7 @@
                     },
                     {
                       "type": "object",
+                      "additionalProperties": true,
                       "properties": {
                         "password": {
                           "type": "string"
@@ -255,6 +257,7 @@
       },
       "AnyValue": {},
       "NameObject": {
+        "additionalProperties": true,
         "required": ["name"],
         "properties": {
           "name": {
@@ -263,6 +266,7 @@
         }
       },
       "EmailObject": {
+        "additionalProperties": true,
         "required": ["email"],
         "properties": {
           "email": {
@@ -271,6 +275,7 @@
         }
       },
       "NameEmailObject": {
+        "additionalProperties": true,
         "type": "object",
         "allOf": [
           {

--- a/tests/example/swagger.json
+++ b/tests/example/swagger.json
@@ -887,6 +887,7 @@
   "definitions": {
     "Order": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "id": {
           "type": "integer",


### PR DESCRIPTION
We cannot simply merge `allOf` schemas, because it can contain different fields (nested `allOf`s, `oneOf`s etc.) that may result in invalid schema after merging.
It's safer and clearer to match schemas one by one, my PR is about that.

In addition, now `additionalProperties`: 
- interpreting - `true` => `{}`, `false` => `null`;
- defaults to `true`

(https://swagger.io/specification/)