### PR TITLE
Remove deprecated var usage

### DIFF
--- a/src/OpenApi/OpenApiSchema.php
+++ b/src/OpenApi/OpenApiSchema.php
@@ -82,7 +82,7 @@ class OpenApiSchema extends Schema
                 }
                 if (!isset($this->jsonFile[self::SWAGGER_COMPONENTS][self::SWAGGER_PARAMETERS][$paramParts[3]])) {
                     throw new DefinitionNotFoundException(
-                        "Not find reference #/components/parameters/${paramParts[3]}"
+                        "Not find reference #/components/parameters/{$paramParts[3]}"
                     );
                 }
                 $parameter = $this->jsonFile[self::SWAGGER_COMPONENTS][self::SWAGGER_PARAMETERS][$paramParts[3]];

--- a/src/Swagger/SwaggerRequestBody.php
+++ b/src/Swagger/SwaggerRequestBody.php
@@ -35,10 +35,10 @@ class SwaggerRequestBody extends Body
             if ($parameter['in'] === "formData") {
                 $hasFormData = true;
                 if (isset($parameter['required']) && $parameter['required'] === true && !isset($body[$parameter['name']])) {
-                    throw new RequiredArgumentNotFound("The formData parameter '${parameter['name']}' is required but it isn't found. ");
+                    throw new RequiredArgumentNotFound("The formData parameter '{$parameter['name']}' is required but it isn't found. ");
                 }
                 if (!$this->matchTypes($parameter['name'], $parameter, (isset($body[$parameter['name']]) ? $body[$parameter['name']] : null))) {
-                    throw new NotMatchedException("The formData parameter '${parameter['name']}' not match with the specification");
+                    throw new NotMatchedException("The formData parameter '{$parameter['name']}' not match with the specification");
                 }
             }
         }


### PR DESCRIPTION
Scenario solved:

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/vendor/byjg/swagger-test/src/OpenApi/OpenApiSchema.php on line 85
