### PR TITLE
Fetch schema from content

### DIFF
--- a/src/Base/Body.php
+++ b/src/Base/Body.php
@@ -361,7 +361,7 @@ abstract class Body
         }
 
         if(!isset($schemaArray['$ref']) && isset($schemaArray['content'])) {
-            $schemaArray['$ref'] = $schemaArray['content'][key($schemaArray['content'])]['schema']['$ref'];
+            $schemaArray = $schemaArray['content'][key($schemaArray['content'])]['schema'];
         }
 
         // Get References and try to match it again


### PR DESCRIPTION
When executing the code `$schemaArray['$ref'] = $schemaArray['content'][key($schemaArray['content'])]['schema']['$ref']`;, there is no guarantee that the '$ref' field exists.