### PR TITLE
Add Parameter to test against the URL and QueryString

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,33 +4,32 @@ To change this license header, choose License Headers in Project Properties.
 To change this template file, choose Tools | Templates
 and open the template in the editor.
 -->
-
 <!-- see http://www.phpunit.de/wiki/Documentation -->
-<phpunit bootstrap="./vendor/autoload.php"
-         colors="true"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="./vendor/autoload.php" colors="true"
          testdox="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          convertDeprecationsToExceptions="true"
-         stopOnFailure="false">
+         stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
 
     <php>
-        <ini name="display_errors" value="On" />
-        <ini name="display_startup_errors" value="On" />
-        <ini name="error_reporting" value="E_ALL" />
+        <ini name="display_errors" value="On"/>
+        <ini name="display_startup_errors" value="On"/>
+        <ini name="error_reporting" value="E_ALL"/>
     </php>
-    
-    <filter>
-        <whitelist>
+
+    <coverage>
+        <include>
             <directory>./src</directory>
-        </whitelist>
-    </filter>
-    
+        </include>
+    </coverage>
+
     <testsuites>
         <testsuite name="Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    
 </phpunit>

--- a/src/Base/Body.php
+++ b/src/Base/Body.php
@@ -209,7 +209,7 @@ abstract class Body
         }
 
         $type = $schemaArray['type'];
-        $nullable = isset($schemaArray['nullable']) ? (bool)$schemaArray['nullable'] : $this->schema->isAllowNullValues();
+        $nullable = isset($schemaArray['nullable']) ? (bool)$schemaArray['nullable'] : ($this->allowNullValues || $this->schema->isAllowNullValues());
 
         $validators = [
             function () use ($name, $body, $type, $nullable)

--- a/src/Base/Parameter.php
+++ b/src/Base/Parameter.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace ByJG\ApiTools\Base;
+
+class Parameter extends Body
+{
+    public function match(mixed $body): bool
+    {
+        return $this->matchSchema($this->name, $this->structure, $body) ?? false;
+    }
+}

--- a/src/OpenApi/OpenApiSchema.php
+++ b/src/OpenApi/OpenApiSchema.php
@@ -3,11 +3,11 @@
 namespace ByJG\ApiTools\OpenApi;
 
 use ByJG\ApiTools\Base\Body;
+use ByJG\ApiTools\Base\Parameter;
 use ByJG\ApiTools\Base\Schema;
 use ByJG\ApiTools\Exception\DefinitionNotFoundException;
 use ByJG\ApiTools\Exception\InvalidDefinitionException;
 use ByJG\ApiTools\Exception\InvalidRequestException;
-use ByJG\ApiTools\Exception\NotMatchedException;
 use ByJG\Util\Uri;
 
 class OpenApiSchema extends Schema
@@ -77,10 +77,9 @@ class OpenApiSchema extends Schema
                 }
                 $parameter = $this->jsonFile[self::SWAGGER_COMPONENTS][self::SWAGGER_PARAMETERS][$paramParts[3]];
             }
-            if ($parameter['in'] === $parameterIn &&
-                $parameter['schema']['type'] === "integer"
-                && filter_var($arguments[$parameter['name']], FILTER_VALIDATE_INT) === false) {
-                throw new NotMatchedException('Path expected an integer value');
+            if ($parameter['in'] === $parameterIn) {
+                $parameterMatch = new Parameter($this, $parameter['name'], $parameter["schema"] ?? [], true);
+                $parameterMatch->match($arguments[$parameter['name']] ?? null);
             }
         }
     }

--- a/src/Swagger/SwaggerSchema.php
+++ b/src/Swagger/SwaggerSchema.php
@@ -3,11 +3,11 @@
 namespace ByJG\ApiTools\Swagger;
 
 use ByJG\ApiTools\Base\Body;
+use ByJG\ApiTools\Base\Parameter;
 use ByJG\ApiTools\Base\Schema;
 use ByJG\ApiTools\Exception\DefinitionNotFoundException;
 use ByJG\ApiTools\Exception\InvalidDefinitionException;
 use ByJG\ApiTools\Exception\InvalidRequestException;
-use ByJG\ApiTools\Exception\NotMatchedException;
 
 class SwaggerSchema extends Schema
 {
@@ -59,10 +59,9 @@ class SwaggerSchema extends Schema
     protected function validateArguments(string $parameterIn, array $parameters, array $arguments): void
     {
         foreach ($parameters as $parameter) {
-            if ($parameter['in'] === $parameterIn
-                && $parameter['type'] === "integer"
-                && filter_var($arguments[$parameter['name']], FILTER_VALIDATE_INT) === false) {
-                throw new NotMatchedException('Path expected an integer value');
+            if ($parameter['in'] === $parameterIn) {
+                $parameterMatch = new Parameter($this, $parameter['name'], $parameter ?? []);
+                $parameterMatch->match($arguments[$parameter['name']] ?? null);
             }
         }
     }

--- a/tests/AbstractRequesterTest.php
+++ b/tests/AbstractRequesterTest.php
@@ -77,7 +77,7 @@ abstract class AbstractRequesterTest extends ApiTestCase
      */
     public function testExpectError()
     {
-        $this->expectException(\ByJG\ApiTools\Exception\NotMatchedException::class);
+        $this->expectException(NotMatchedException::class);
         $this->expectExceptionMessage("Required property 'name'");
         
         $expectedResponse = Response::getInstance(200)
@@ -91,6 +91,26 @@ abstract class AbstractRequesterTest extends ApiTestCase
             ->withMethod('GET')
             ->withPath("/pet/1");
 
+        $this->assertRequest($request);
+    }
+
+    public function testExpectParamError()
+    {
+        $expectedResponse = Response::getInstance(200)
+            ->withBody(new MemoryStream(json_encode([
+                "id" => 1,
+                "name" => "Spike",
+                "photoUrls" => []
+            ])));
+
+        // Basic Request
+        $request = new MockRequester($expectedResponse);
+        $request
+            ->withMethod('GET')
+            ->withPath("/pet/ABC");
+
+        $this->expectException(NotMatchedException::class);
+        $this->expectExceptionMessage("Expected 'petId' to be numeric, but found 'ABC'.");
         $this->assertRequest($request);
     }
 
@@ -166,7 +186,7 @@ abstract class AbstractRequesterTest extends ApiTestCase
      */
     public function testValidateAssertResponse404WithContent()
     {
-        $this->expectException(\ByJG\ApiTools\Exception\NotMatchedException::class);
+        $this->expectException(NotMatchedException::class);
         $this->expectExceptionMessage("Expected empty body for GET 404 /v2/pet/1");
         
         $expectedResponse = Response::getInstance(404)
@@ -258,7 +278,7 @@ abstract class AbstractRequesterTest extends ApiTestCase
      */
     public function testValidateAssertHeaderContainsWrongValue()
     {
-        $this->expectException(\ByJG\ApiTools\Exception\NotMatchedException::class);
+        $this->expectException(NotMatchedException::class);
         $this->expectExceptionMessage("Does not exists header 'X-Test' with value 'Different'");
         
         $expectedResponse = Response::getInstance(200)
@@ -294,7 +314,7 @@ abstract class AbstractRequesterTest extends ApiTestCase
      */
     public function testValidateAssertHeaderContainsNonExistent()
     {
-        $this->expectException(\ByJG\ApiTools\Exception\NotMatchedException::class);
+        $this->expectException(NotMatchedException::class);
         $this->expectExceptionMessage("Does not exists header 'X-Test' with value 'Different'");
         
         $expectedResponse = Response::getInstance(200)
@@ -361,7 +381,7 @@ abstract class AbstractRequesterTest extends ApiTestCase
      */
     public function testValidateAssertBodyNotContains()
     {
-        $this->expectException(\ByJG\ApiTools\Exception\NotMatchedException::class);
+        $this->expectException(NotMatchedException::class);
         $this->expectExceptionMessage("Body does not contain 'Doris'");
         
         $expectedResponse = Response::getInstance(200)

--- a/tests/OpenApiRequestBodyTest.php
+++ b/tests/OpenApiRequestBodyTest.php
@@ -3,23 +3,25 @@
 namespace Tests;
 
 use ByJG\ApiTools\Exception\DefinitionNotFoundException;
+use ByJG\ApiTools\Exception\GenericSwaggerException;
 use ByJG\ApiTools\Exception\HttpMethodNotFoundException;
 use ByJG\ApiTools\Exception\InvalidDefinitionException;
 use ByJG\ApiTools\Exception\InvalidRequestException;
 use ByJG\ApiTools\Exception\NotMatchedException;
 use ByJG\ApiTools\Exception\PathNotFoundException;
+use ByJG\ApiTools\Exception\RequiredArgumentNotFound;
 
 class OpenApiRequestBodyTest extends OpenApiBodyTestCase
 {
     /**
-     * @throws \ByJG\ApiTools\Exception\DefinitionNotFoundException
-     * @throws \ByJG\ApiTools\Exception\GenericSwaggerException
-     * @throws \ByJG\ApiTools\Exception\HttpMethodNotFoundException
-     * @throws \ByJG\ApiTools\Exception\InvalidDefinitionException
-     * @throws \ByJG\ApiTools\Exception\InvalidRequestException
-     * @throws \ByJG\ApiTools\Exception\NotMatchedException
-     * @throws \ByJG\ApiTools\Exception\PathNotFoundException
-     * @throws \ByJG\ApiTools\Exception\RequiredArgumentNotFound
+     * @throws DefinitionNotFoundException
+     * @throws GenericSwaggerException
+     * @throws HttpMethodNotFoundException
+     * @throws InvalidDefinitionException
+     * @throws InvalidRequestException
+     * @throws NotMatchedException
+     * @throws PathNotFoundException
+     * @throws RequiredArgumentNotFound
      */
     public function testMatchRequestBody()
     {
@@ -38,18 +40,18 @@ class OpenApiRequestBodyTest extends OpenApiBodyTestCase
 
     /**
      *
-     * @throws \ByJG\ApiTools\Exception\DefinitionNotFoundException
-     * @throws \ByJG\ApiTools\Exception\GenericSwaggerException
-     * @throws \ByJG\ApiTools\Exception\HttpMethodNotFoundException
-     * @throws \ByJG\ApiTools\Exception\InvalidDefinitionException
-     * @throws \ByJG\ApiTools\Exception\InvalidRequestException
-     * @throws \ByJG\ApiTools\Exception\NotMatchedException
-     * @throws \ByJG\ApiTools\Exception\PathNotFoundException
-     * @throws \ByJG\ApiTools\Exception\RequiredArgumentNotFound
+     * @throws DefinitionNotFoundException
+     * @throws GenericSwaggerException
+     * @throws HttpMethodNotFoundException
+     * @throws InvalidDefinitionException
+     * @throws InvalidRequestException
+     * @throws NotMatchedException
+     * @throws PathNotFoundException
+     * @throws RequiredArgumentNotFound
      */
     public function testMatchRequiredRequestBodyEmpty()
     {
-        $this->expectException(\ByJG\ApiTools\Exception\RequiredArgumentNotFound::class);
+        $this->expectException(RequiredArgumentNotFound::class);
         $this->expectExceptionMessage("The body is required");
         
         $requestParameter = self::openApiSchema()->getRequestParameters('/v2/store/order', 'post');
@@ -58,18 +60,18 @@ class OpenApiRequestBodyTest extends OpenApiBodyTestCase
 
     /**
      *
-     * @throws \ByJG\ApiTools\Exception\DefinitionNotFoundException
-     * @throws \ByJG\ApiTools\Exception\GenericSwaggerException
-     * @throws \ByJG\ApiTools\Exception\HttpMethodNotFoundException
-     * @throws \ByJG\ApiTools\Exception\InvalidDefinitionException
-     * @throws \ByJG\ApiTools\Exception\InvalidRequestException
-     * @throws \ByJG\ApiTools\Exception\NotMatchedException
-     * @throws \ByJG\ApiTools\Exception\PathNotFoundException
-     * @throws \ByJG\ApiTools\Exception\RequiredArgumentNotFound
+     * @throws DefinitionNotFoundException
+     * @throws GenericSwaggerException
+     * @throws HttpMethodNotFoundException
+     * @throws InvalidDefinitionException
+     * @throws InvalidRequestException
+     * @throws NotMatchedException
+     * @throws PathNotFoundException
+     * @throws RequiredArgumentNotFound
      */
     public function testMatchInexistantBodyDefinition()
     {
-        $this->expectException(\ByJG\ApiTools\Exception\InvalidDefinitionException::class);
+        $this->expectException(InvalidDefinitionException::class);
         $this->expectExceptionMessage("Body is passed but there is no request body definition");
         
         $body = [
@@ -96,8 +98,8 @@ class OpenApiRequestBodyTest extends OpenApiBodyTestCase
      */
     public function testMatchDataType()
     {
-        $this->expectException(\ByJG\ApiTools\Exception\NotMatchedException::class);
-        $this->expectExceptionMessage("Path expected an integer value");
+        $this->expectException(NotMatchedException::class);
+        $this->expectExceptionMessage("Expected 'petId' to be numeric, but found 'STRING'");
         
         self::openApiSchema()->getRequestParameters('/v2/pet/STRING', 'get');
         $this->assertTrue(true);
@@ -117,6 +119,14 @@ class OpenApiRequestBodyTest extends OpenApiBodyTestCase
     {
         self::openApiSchema()->getRequestParameters('/v2/pet/findByStatus?status=pending', 'get');
         $this->assertTrue(true);
+    }
+
+    public function testMatchParameterInQueryNotValid()
+    {
+        $this->expectException(NotMatchedException::class);
+        $this->expectExceptionMessage("Value 'ABC' in 'status' not matched in ENUM");
+
+        self::openApiSchema()->getRequestParameters('/v2/pet/findByStatus?status=ABC', 'get');
     }
 
     /**
@@ -144,28 +154,51 @@ class OpenApiRequestBodyTest extends OpenApiBodyTestCase
      */
     public function testMatchParameterInQuery3()
     {
-        $this->expectException(\ByJG\ApiTools\Exception\NotMatchedException::class);
-        $this->expectExceptionMessage("Path expected an integer value");
+        $this->expectException(NotMatchedException::class);
+        $this->expectExceptionMessage("Expected 'test_id' to be numeric, but found 'STRING'");
         
         self::openApiSchema3()->getRequestParameters('/tests/STRING?count=20&offset=2', 'get');
         $this->assertTrue(true);
     }
 
+    public function testMatchParameterInQuery4()
+    {
+        $this->expectException(NotMatchedException::class);
+        $this->expectExceptionMessage("Expected 'count' to be numeric, but found 'ABC'");
+
+        self::openApiSchema3()->getRequestParameters('/tests/12345?count=ABC&offset=2', 'get');
+        $this->assertTrue(true);
+    }
+
+    public function testMatchParameterInQuery5()
+    {
+        $this->expectException(NotMatchedException::class);
+        $this->expectExceptionMessage("Expected 'offset' to be numeric, but found 'ABC'");
+
+        self::openApiSchema3()->getRequestParameters('/tests/12345?count=20&offset=ABC', 'get');
+        $this->assertTrue(true);
+    }
+
+    public function testMatchParameterInQuery6()
+    {
+        self::openApiSchema3()->getRequestParameters('/tests/12345', 'get');
+        $this->assertTrue(true);
+    }
 
     /**
      *
-     * @throws \ByJG\ApiTools\Exception\DefinitionNotFoundException
-     * @throws \ByJG\ApiTools\Exception\GenericSwaggerException
-     * @throws \ByJG\ApiTools\Exception\HttpMethodNotFoundException
-     * @throws \ByJG\ApiTools\Exception\InvalidDefinitionException
-     * @throws \ByJG\ApiTools\Exception\InvalidRequestException
-     * @throws \ByJG\ApiTools\Exception\NotMatchedException
-     * @throws \ByJG\ApiTools\Exception\PathNotFoundException
-     * @throws \ByJG\ApiTools\Exception\RequiredArgumentNotFound
+     * @throws DefinitionNotFoundException
+     * @throws GenericSwaggerException
+     * @throws HttpMethodNotFoundException
+     * @throws InvalidDefinitionException
+     * @throws InvalidRequestException
+     * @throws NotMatchedException
+     * @throws PathNotFoundException
+     * @throws RequiredArgumentNotFound
      */
     public function testMatchRequestBodyRequired1()
     {
-        $this->expectException(\ByJG\ApiTools\Exception\NotMatchedException::class);
+        $this->expectException(NotMatchedException::class);
         $this->expectExceptionMessage("Required property");
         
         $body = [
@@ -181,18 +214,18 @@ class OpenApiRequestBodyTest extends OpenApiBodyTestCase
      * It is not OK when allowNullValues is false (as by default) { name: null }
      * https://stackoverflow.com/questions/45575493/what-does-required-in-openapi-really-mean
      *
-     * @throws \ByJG\ApiTools\Exception\DefinitionNotFoundException
-     * @throws \ByJG\ApiTools\Exception\GenericSwaggerException
-     * @throws \ByJG\ApiTools\Exception\HttpMethodNotFoundException
-     * @throws \ByJG\ApiTools\Exception\InvalidDefinitionException
-     * @throws \ByJG\ApiTools\Exception\InvalidRequestException
-     * @throws \ByJG\ApiTools\Exception\NotMatchedException
-     * @throws \ByJG\ApiTools\Exception\PathNotFoundException
-     * @throws \ByJG\ApiTools\Exception\RequiredArgumentNotFound
+     * @throws DefinitionNotFoundException
+     * @throws GenericSwaggerException
+     * @throws HttpMethodNotFoundException
+     * @throws InvalidDefinitionException
+     * @throws InvalidRequestException
+     * @throws NotMatchedException
+     * @throws PathNotFoundException
+     * @throws RequiredArgumentNotFound
      */
     public function testMatchRequestBodyRequiredNullsNotAllowed()
     {
-        $this->expectException(\ByJG\ApiTools\Exception\NotMatchedException::class);
+        $this->expectException(NotMatchedException::class);
         $this->expectExceptionMessage("Value of property 'name' is null, but should be of type 'string'");
         
         $body = [
@@ -207,14 +240,14 @@ class OpenApiRequestBodyTest extends OpenApiBodyTestCase
     }
 
     /**
-     * @throws \ByJG\ApiTools\Exception\DefinitionNotFoundException
-     * @throws \ByJG\ApiTools\Exception\GenericSwaggerException
-     * @throws \ByJG\ApiTools\Exception\HttpMethodNotFoundException
-     * @throws \ByJG\ApiTools\Exception\InvalidDefinitionException
-     * @throws \ByJG\ApiTools\Exception\InvalidRequestException
-     * @throws \ByJG\ApiTools\Exception\NotMatchedException
-     * @throws \ByJG\ApiTools\Exception\PathNotFoundException
-     * @throws \ByJG\ApiTools\Exception\RequiredArgumentNotFound
+     * @throws DefinitionNotFoundException
+     * @throws GenericSwaggerException
+     * @throws HttpMethodNotFoundException
+     * @throws InvalidDefinitionException
+     * @throws InvalidRequestException
+     * @throws NotMatchedException
+     * @throws PathNotFoundException
+     * @throws RequiredArgumentNotFound
      */
     public function testMatchRequestBodyRequiredNullsAllowed()
     {
@@ -234,14 +267,14 @@ class OpenApiRequestBodyTest extends OpenApiBodyTestCase
      * It is OK: { name: ""}
      * https://stackoverflow.com/questions/45575493/what-does-required-in-openapi-really-mean
      *
-     * @throws \ByJG\ApiTools\Exception\DefinitionNotFoundException
-     * @throws \ByJG\ApiTools\Exception\GenericSwaggerException
-     * @throws \ByJG\ApiTools\Exception\HttpMethodNotFoundException
-     * @throws \ByJG\ApiTools\Exception\InvalidDefinitionException
-     * @throws \ByJG\ApiTools\Exception\InvalidRequestException
-     * @throws \ByJG\ApiTools\Exception\NotMatchedException
-     * @throws \ByJG\ApiTools\Exception\PathNotFoundException
-     * @throws \ByJG\ApiTools\Exception\RequiredArgumentNotFound
+     * @throws DefinitionNotFoundException
+     * @throws GenericSwaggerException
+     * @throws HttpMethodNotFoundException
+     * @throws InvalidDefinitionException
+     * @throws InvalidRequestException
+     * @throws NotMatchedException
+     * @throws PathNotFoundException
+     * @throws RequiredArgumentNotFound
      */
     public function testMatchRequestBodyRequired3()
     {
@@ -259,14 +292,14 @@ class OpenApiRequestBodyTest extends OpenApiBodyTestCase
     /**
      * issue #21
      *
-     * @throws \ByJG\ApiTools\Exception\DefinitionNotFoundException
-     * @throws \ByJG\ApiTools\Exception\GenericSwaggerException
-     * @throws \ByJG\ApiTools\Exception\HttpMethodNotFoundException
-     * @throws \ByJG\ApiTools\Exception\InvalidDefinitionException
-     * @throws \ByJG\ApiTools\Exception\InvalidRequestException
-     * @throws \ByJG\ApiTools\Exception\NotMatchedException
-     * @throws \ByJG\ApiTools\Exception\PathNotFoundException
-     * @throws \ByJG\ApiTools\Exception\RequiredArgumentNotFound
+     * @throws DefinitionNotFoundException
+     * @throws GenericSwaggerException
+     * @throws HttpMethodNotFoundException
+     * @throws InvalidDefinitionException
+     * @throws InvalidRequestException
+     * @throws NotMatchedException
+     * @throws PathNotFoundException
+     * @throws RequiredArgumentNotFound
      */
     public function testMatchRequestBodyRequired_Issue21()
     {
@@ -283,18 +316,18 @@ class OpenApiRequestBodyTest extends OpenApiBodyTestCase
     /**
      * Issue #21
      *
-     * @throws \ByJG\ApiTools\Exception\DefinitionNotFoundException
-     * @throws \ByJG\ApiTools\Exception\GenericSwaggerException
-     * @throws \ByJG\ApiTools\Exception\HttpMethodNotFoundException
-     * @throws \ByJG\ApiTools\Exception\InvalidDefinitionException
-     * @throws \ByJG\ApiTools\Exception\InvalidRequestException
-     * @throws \ByJG\ApiTools\Exception\NotMatchedException
-     * @throws \ByJG\ApiTools\Exception\PathNotFoundException
-     * @throws \ByJG\ApiTools\Exception\RequiredArgumentNotFound
+     * @throws DefinitionNotFoundException
+     * @throws GenericSwaggerException
+     * @throws HttpMethodNotFoundException
+     * @throws InvalidDefinitionException
+     * @throws InvalidRequestException
+     * @throws NotMatchedException
+     * @throws PathNotFoundException
+     * @throws RequiredArgumentNotFound
      */
     public function testMatchRequestBodyRequired_Issue21_Required()
     {
-        $this->expectException(\ByJG\ApiTools\Exception\NotMatchedException::class);
+        $this->expectException(NotMatchedException::class);
         $this->expectExceptionMessage("Required property 'user_uuid'");
         
         // Missing Request

--- a/tests/OpenApiResponseBodyTest.php
+++ b/tests/OpenApiResponseBodyTest.php
@@ -432,7 +432,7 @@ class OpenApiResponseBodyTest extends OpenApiBodyTestCase
                 ],
             ];
 
-        $responseParameter = $this->openApiSchema2()->getResponseParameters('/v2/languages', 'get', 200);
+        $responseParameter = $this->openApiSchema2()->getResponseParameters('/v2/languages?site=test', 'get', 200);
         $this->assertTrue($responseParameter->match($body));
     }
 
@@ -466,7 +466,7 @@ class OpenApiResponseBodyTest extends OpenApiBodyTestCase
                 ]
             ];
 
-        $responseParameter = $this->openApiSchema2()->getResponseParameters('/v2/languages', 'get', 200);
+        $responseParameter = $this->openApiSchema2()->getResponseParameters('/v2/languages?site=test', 'get', 200);
         $this->assertTrue($responseParameter->match($body));
     }
 
@@ -547,6 +547,6 @@ class OpenApiResponseBodyTest extends OpenApiBodyTestCase
         $this->expectExceptionMessage("Could not found status code '503'");
         
         $body = [];
-        $responseParameter = $this->openApiSchema()->getResponseParameters('/v2/user/login', 'get', 503);
+        $responseParameter = $this->openApiSchema()->getResponseParameters('/v2/user/login?username=foo&password=bar', 'get', 503);
     }
 }

--- a/tests/SwaggerRequestBodyTest.php
+++ b/tests/SwaggerRequestBodyTest.php
@@ -94,7 +94,7 @@ class SwaggerRequestBodyTest extends SwaggerBodyTestCase
     public function testMatchDataType()
     {
         $this->expectException(\ByJG\ApiTools\Exception\NotMatchedException::class);
-        $this->expectExceptionMessage("Path expected an integer value");
+        $this->expectExceptionMessage("Expected 'petId' to be numeric, but found 'STRING'");
         
         self::swaggerSchema()->getRequestParameters('/v2/pet/STRING', 'get');
         $this->assertTrue(true);

--- a/tests/SwaggerResponseBodyTest.php
+++ b/tests/SwaggerResponseBodyTest.php
@@ -479,7 +479,7 @@ EOL
                 ]
             ],
         ];
-        $responseParameter = $this->swaggerSchema2()->getResponseParameters('/v2/languages', 'get', 200);
+        $responseParameter = $this->swaggerSchema2()->getResponseParameters('/v2/languages?site=test', 'get', 200);
         $this->assertTrue($responseParameter->match($body));
     }
 
@@ -513,7 +513,7 @@ EOL
                     "isDefault" => false
                 ]
             ];
-        $responseParameter = $this->swaggerSchema2()->getResponseParameters('/v2/languages', 'get', 200);
+        $responseParameter = $this->swaggerSchema2()->getResponseParameters('/v2/languages?site=test', 'get', 200);
         $this->assertTrue($responseParameter->match($body));
     }
 
@@ -574,6 +574,6 @@ EOL
         $this->expectExceptionMessage("Could not found status code '503'");
         
         $body = [];
-        $responseParameter = $this->swaggerSchema()->getResponseParameters('/v2/user/login', 'get', 503);
+        $responseParameter = $this->swaggerSchema()->getResponseParameters('/v2/user/login?username=foo&password=bar', 'get', 503);
     }
 }


### PR DESCRIPTION
This PR adds the validation against the URL parameter and Query String.

The definition `in query`:

```yaml
parameters:
  - name: status
    in: query
    description: Status values that need to be considered for filter
    required: true
    explode: true
    schema:
      type: array
      items:
        type: string
        enum:
          - available
          - pending
          - sold
        default: available
```

or `in path`

```yaml
parameters:
  - name: site
    in: path
    description: "Application context\n\nExample: 'sl'\n"
    required: true
    schema:
      type: string
```

Weren't validate. With this PR the system will validate properly
