### PR TITLE
Adjust to allow POST endpoints that return text/html responses.

### DIFF
--- a/src/OpenApi/OpenApiResponseBody.php
+++ b/src/OpenApi/OpenApiResponseBody.php
@@ -23,7 +23,16 @@ class OpenApiResponseBody extends Body
             $definition = $this->schema->getDefinition($this->structure['$ref']);
             return $this->matchSchema($this->name, $definition, $body) ?? false;
         }
-        
-        return $this->matchSchema($this->name, $this->structure['content'][key($this->structure['content'])]['schema'], $body) ?? false;
+
+        foreach ($this->structure['content'] as $contentType => $schema) {
+            if ($contentType === 'application/json') {
+                if (!isset($schema['schema'])) {
+                    throw new NotMatchedException("Content type " . $contentType . " does not have schema");
+                }
+                return $this->matchSchema($this->name, $schema['schema'], $body) ?? false;
+            }
+        }
+
+        return true;
     }
 }

--- a/tests/OpenApiResponseBodyTest.php
+++ b/tests/OpenApiResponseBodyTest.php
@@ -65,6 +65,23 @@ class OpenApiResponseBodyTest extends OpenApiBodyTestCase
         $this->assertTrue($responseParameter->match($body));
     }
 
+    public function testMatchResponseBodyWithHtmlResponse()
+    {
+        $openApiSchema = self::openApiSchema();
+
+        $body = [
+            "id" => 10,
+            "petId" => 50,
+            "quantity" => 1,
+            "shipDate" => '2010-10-20',
+            "status" => 'placed',
+            "complete" => true
+        ];
+
+        $responseParameter = $openApiSchema->getResponseParameters('/v2/store/orderhtml', 'post', 200);
+        $this->assertTrue($responseParameter->match($body));
+    }
+
     /**
      * @throws DefinitionNotFoundException
      * @throws GenericSwaggerException

--- a/tests/example/openapi.json
+++ b/tests/example/openapi.json
@@ -564,6 +564,38 @@
         }
       }
     },
+    "/store/orderhtml": {
+      "post": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Place an order for a pet",
+        "description": "",
+        "operationId": "placeOrder",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Order"
+              }
+            }
+          },
+          "description": "order placed for purchasing the pet",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The object to be created",
+            "content": {
+              "text/html": {}
+            }
+          },
+          "400": {
+            "description": "Invalid Order"
+          }
+        }
+      }
+    },
     "/store/order/{orderId}": {
       "get": {
         "tags": [


### PR DESCRIPTION
This PR fixes the error message "Undefined array schema" on "OpenApiReponseBody::match" function when the application has an endpoint with the method POST and the response content type is text/html.